### PR TITLE
Corrected exported path for bash and added support for debian

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -36,7 +36,7 @@ then
         echo "Congrats, you run arch..."
         echo "Ok so you need doctl - so get that from the AUR :) You're smart! You installed arch!"
         sudo pacman -S fzf packer jq
-    elif [ $OS == "Ubuntu" ]
+    elif [ $OS == "Ubuntu" ] || [ $OS == "Debian" ]
     then
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
@@ -136,7 +136,7 @@ if [ "$SHELL" == "/usr/local/bin/zsh" ]; then
     echo "export PATH=\"\$PATH:\$HOME/.axiom/interact\"" >> ~/.zshrc
 elif [ "$SHELL" == "/bin/bash" ]; then
     echo "You're running Bash! Installing Axiom to \$PATH..."
-    echo "export PATH=\"\$PATH:\$HOME/.axiom/interact\"" >> ~/.zshrc
+    echo "export PATH=\"\$PATH:\$HOME/.axiom/interact\"" >> ~/.bashrc
 else
     echo "I don't have a predefined setup for your shell!"
     echo "Please add ~/.axiom/interact to your \$PATH!"


### PR DESCRIPTION
Since Debian and Ubuntu behaves same, but debian variant was not mentioned, it was failing in my case. I added it to rectify.