### PR TITLE
Adding commands to run `axiom-configure` in Fedora.

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -65,6 +65,12 @@ then
         wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
         sudo apt-get update && sudo apt-get install fzf git
         sudo snap install doctl
+    elif [ $OS == "Fedora" ]
+    then
+        sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
+        wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
+        sudo dnf -y update && sudo dnf -y install fzf git
+        wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf doctl.tar.gz && sudo mv doctl /usr/bin
     fi
 fi
 


### PR DESCRIPTION
This adds the commands to install the requirements in Fedora. As `doctl` is not available a direct download from github was used. Also, `lsb_release` is not installed by default so the `$OS`
variable might cause a failure. 

So, in order to use this patch the `redhat-lsb-release` package must be installed. Another option could
be to parse the content of `/etc/os-release` but I'm not sure if that works in Debian/Ubuntu and Arch.