### PR TITLE
improve zsh detection

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -166,7 +166,7 @@ else
     fi
 fi
 
-if [ "$SHELL" == "/usr/local/bin/zsh" ]; then
+if [ "$SHELL" == "/usr/local/bin/zsh" ] || [ "$SHELL" == "/usr/bin/zsh" ]; then
     echo -e "${Green}You're running ZSH! Installing Axiom to \$PATH...${Color_Off}"
     echo "export PATH=\"\$PATH:\$HOME/.axiom/interact\"" >> ~/.zshrc
     echo "source $HOME/.axiom/functions/autocomplete.zsh" >> ~/.zshrc


### PR DESCRIPTION
Default location is /usr/bin/zsh for Ubuntu, Fedora and probably other Linux systems, this minor patch adds support for this alternate path.