### PR TITLE
Typo may be, renamed Go to go so that tools install at correct place

### DIFF
--- a/configs/bashrc
+++ b/configs/bashrc
@@ -1,7 +1,7 @@
 
 # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
 export PATH="$PATH:$HOME/.rvm/bin"
-export GOPATH=~/Go
+export GOPATH=~/go
 
 alias msfconsole="rvmsudo ~/Pentesting/Exploitation/msf/msfconsole"
 alias ls="ls --color=auto"


### PR DESCRIPTION
Because of this typo, even if you install new go tools, those will not be under $PATH, so they will not run.