### PR TITLE
Added manjaro detection to axiom-configure

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -59,7 +59,7 @@ then
     else    
         OS=$(lsb_release -i | awk '{ print $3 }')
     fi    
-    if [ $OS == "Arch" ]
+    if [ $OS == "Arch" ] || [$OS == "ManjaroLinux"]
     then
         echo -e "${Blue}Congrats, you run arch..."
         echo -e "Ok so you need doctl - so get that from the AUR :) yay -S doctl! You're smart! You installed arch! ${Color_Off}"


### PR DESCRIPTION
Simple fix to add dependencies for Manjaro, as it's the same as arch under the hood.