### PR TITLE
WSL 2 Fix

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -53,7 +53,7 @@ esac
 
 if [ $BASEOS == "Linux" ]
 then
-    if $(uname -a | grep -q "Microsoft")
+    if $(uname -a | grep -qi "Microsoft")
     then
         OS="UbuntuWSL"
     else    


### PR DESCRIPTION
On Ubuntu 20.04 running under WSL *2* my `uname -a` output is:

```
Linux LAPTOP-FFTCOFDU 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

Since the configure script greps for "Microsoft" (capitalised) this doesn't match and it proceeds as if it is regular Ubuntu. It then fails because unzip and snap aren't installed.

Simple fix is to ignore case. And with that I've successfully created my first instance 🙂 