### PR TITLE
axiom-init: Read doctl config from correct path on OSX

### DIFF
--- a/interact/axiom-init
+++ b/interact/axiom-init
@@ -3,12 +3,18 @@
 AXIOM_PATH="$HOME/.axiom"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 
+BASEOS="$(uname)"
+DOCTL_CONFIG_PATH="~/.config/doctl/config.yaml"
+
+# Per doctl readme the config path differs on OSX: https://github.com/digitalocean/doctl#configuring-default-values
+if [ $BASEOS == "Darwin" ]; then DOCTL_CONFIG_PATH=~/"Library/Application Support/doctl/config.yaml"; fi
+
 if ! command -v doctl &> /dev/null
 then
     echo -e "${BRed}Error: doctl could not be found. Please install it from the binary${No_Color}"
     exit
 else
-	token_length=$(cat ~/.config/doctl/config.yaml  | grep access-token | wc -c | awk '{ print $1 }')
+	token_length=$(cat "$DOCTL_CONFIG_PATH"  | grep access-token | wc -c | awk '{ print $1 }')
 	if [[ "$token_length" -lt 32 ]];
 	then
 		echo -e "${Red}Warning: it looks like your doctl might not be configured with a token!${Color_Off}"


### PR DESCRIPTION
As per the doctl [readme](https://github.com/digitalocean/doctl#configuring-default-values) on OSX its config file is located at `${HOME}/Library/Application Support/doctl/config.yaml` instead of `${HOME}/.config/doctl/config.yaml` which is the default on other platforms.

On OSX this differing path leads to an error:
`Warning: it looks like your doctl might not be configured with a token!`

This PR sets the doctl config path in `axiom-init` according to the OS so no errors will be thrown.