### PR TITLE
[setup][configure] Check for lsb_release binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The main trouble here is just the dependencies.
 - Packer - Tested with v1.5.6
 - fzf - Tested with 0.21.1
 - doctl - Tested with 1.43
+- lsb_release - Tested with 1.4 (but any version should be ok)
 - jq - Tested with 1.6 (latest is better for this one)
 
 Packer is pretty easy everywhere, although manual (its really important you get the right version, if its too old, then the var-file syntax will fail.

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -35,6 +35,11 @@ if [ $BASEOS == "Linux" ]; then
 	if $(uname -a | grep -qi "Microsoft"); then
 		OS="UbuntuWSL"
 	else
+		if ! command -v lsb_release &> /dev/null; then
+			echo "lsb_release could not be found, unable to determine your distribution"
+			echo "If you are using Arch, please get lsb_release from AUR"
+			exit 1
+		fi
 		OS=$(lsb_release -i | awk '{ print $3 }')
 	fi
 	if [ $OS == "Arch" ] || [ $OS == "ManjaroLinux" ]; then
@@ -145,7 +150,7 @@ else
 	fi
 fi
 
-if [ "$SHELL" == "/usr/local/bin/zsh" ] || [ "$SHELL" == "/usr/bin/zsh" ]; then
+if [ "$SHELL" == "/usr/local/bin/zsh" ] || [ "$SHELL" == "/usr/bin/zsh" ] || [ "$SHELL" == "/bin/zsh" ]; then
 	echo -e "${Green}You're running ZSH! Installing Axiom to \$PATH...${Color_Off}"
 	echo "export PATH=\"\$PATH:\$HOME/.axiom/interact\"" >>~/.zshrc
 	echo "source $HOME/.axiom/functions/autocomplete.zsh" >>~/.zshrc
@@ -168,7 +173,7 @@ fi
 
 export PATH="$PATH:$HOME/.axiom/interact"
 
-echo "{\"do_key\":\"$do_key\", \"region\":\"$region\", \"domain\":\"$domain\", \"default_size\":\"$size\", \"hunter_key\":\"$hunter_key\"}" | jq >$AXIOM_PATH/axiom.json
+echo "{\"do_key\":\"$do_key\", \"region\":\"$region\", \"domain\":\"$domain\", \"default_size\":\"$size\", \"hunter_key\":\"$hunter_key\"}" | jq > $AXIOM_PATH/axiom.json
 
 echo -e "${BWhite}Beginning first packer build...${Color_Off}"
 cd $AXIOM_PATH/


### PR DESCRIPTION
Check for the `lsb_release` binary that might be missing from the system.
As we can't determine which OS is running I think this should be a "fatal" error and the setup should stop.
This commit also includes an update to the README as well as an alternate path to ZSH location.

Thanks !