### PR TITLE
Fixes for outfile path and notification sending errors

### DIFF
--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -123,7 +123,7 @@ then
 			echo -e "${BGreen}File saved to $outfile${Color_Off}"
 		elif [[ "$outformat" == "xml" ]];
 		then
-			"$AXIOM_PATH/interact/merge-xml.py" -d "$src_prefix" -o "$(PWD)/$outfile"
+			"$AXIOM_PATH/interact/merge-xml.py" -d "$src_prefix" -o "$PWD/$outfile"
 		fi
 	fi
 

--- a/interact/includes/system-notification.sh
+++ b/interact/includes/system-notification.sh
@@ -6,7 +6,7 @@ BASEOS="$(uname)"
 # method issuing notifications for at least most ubuntu like systems
 # expects a title as first and a notification as second argument
 function notify {
-  notify-send "$1" "$2"
+  [ -x "$(command -v notify-send)" ] && notify-send "$1" "$2"
 }
 
 # method issuing notifications in place of notify-send on OSX


### PR DESCRIPTION
First commit will fix this:

`/home/rst/.axiom/interact/axiom-scan: line 126: PWD: command not found`

Second commit will check if notify-send is installed on the system before sending notifications, useful when on a system without a desktop environment. Fixes this:

`/home/rst/.axiom/interact/includes/system-notification.sh: line 9: notify-send: command not found` 