### PR TITLE
Added logic incase answer is 'n' or something else

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -138,6 +138,18 @@ if [ -f ~/.ssh/id_rsa.pub ] || [ -f ~/.ssh/id_ed25519.pub ]; then
 		elif [ -f ~/.ssh/id_ed25519.pub ]; then
 			cat ~/.ssh/id_ed25519.pub >$AXIOM_PATH/configs/authorized_keys
 		fi
+	else	
+		echo -e "${Blue}Would you like to generate a fresh pair? y/n ${Color_Off}"
+		read ans
+		if [ $ans == "y" ]; then
+			ssh-keygen
+			cat ~/.ssh/id_rsa.pub >$AXIOM_PATH/configs/authorized_keys
+		
+		else
+			echo -e "${Blue}Need to provide SSH public key. Exiting...  ${Color_Off}"
+			exit 0
+		fi
+
 	fi
 else
 	echo -e "${Blue}No SSH public key detected, would you like to generate a fresh pair? y/n ${Color_Off}"
@@ -145,6 +157,9 @@ else
 	if [ $ans == "y" ]; then
 		ssh-keygen
 		cat ~/.ssh/id_rsa.pub >$AXIOM_PATH/configs/authorized_keys
+	else
+			echo -e "${Blue}Need to provide SSH public key. Exiting...  ${Color_Off}"
+			exit 0
 	fi
 fi
 


### PR DESCRIPTION
Hey!

I created this PR based on what happened to the earlier PR. If this is not how you want the logic to flow then just close the PR.

This PR adds logic to stop the user from not entering any keys in. If the user has pre defined SSH keys and answers n or any other response it will ask them if they want to generate new keys. If they say no to this it will exit the configure script. If the script doesn't detect keys and asks if the user wants to generate new keys and the user reply's no or anything else it will exit. 

I have tested locally and appears to work. May want to go over it though and test your self before Merging based on what happened earlier. Just thought this might clean the script up, no worries if you don't think it's needed or what i added is crap lol