### PR TITLE
Added axiom-rename to allow renaming droplets

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ It requires no arguments.
 ## `axiom-rm`
 `axiom-rm` is used to remove a machine, if you have a machine initalised, you can completely rm it by using `axiom-rm <instance>`.
 
+## `axiom-rename`
+`axiom-rename` is used to rename droplet. For example `axiom-rename noyce-14 noyce-14-renamed` will change name of a droplet from noyce-14 to noyce-14-renamed.
+
 ## `axiom-scp`
 `axiom-scp` allows copying files between the host and the target machine, wrapping the traditional `scp` command but you can use the machine name instead. For example: `axiom-scp file.txt noyce-14:file.txt` will copy your local file.txt to your `noyce-14` machine.
 

--- a/interact/axiom-rename
+++ b/interact/axiom-rename
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-AXIOM_PATH="$HOME/axiom_contribution/axiom/"
+AXIOM_PATH="$HOME/.axiom"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 source "$AXIOM_PATH/interact/includes/functions.sh"
 
 droplet="$1"
 new_name="$2"
 droplet_id=$(instance_id $droplet)
-echo $droplet_id
 result=$(doctl compute droplet-action rename $droplet_id --droplet-name $new_name)
-echo $result

--- a/interact/axiom-rename
+++ b/interact/axiom-rename
@@ -4,7 +4,16 @@ AXIOM_PATH="$HOME/.axiom"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 source "$AXIOM_PATH/interact/includes/functions.sh"
 
-droplet="$1"
-new_name="$2"
-droplet_id=$(instance_id $droplet)
-result=$(doctl compute droplet-action rename $droplet_id --droplet-name $new_name)
+if [[ $# -ne 2 ]]; then
+	echo "Usage:"
+	echo "axiom-rename current_droplet_name new_droplet_name"
+else
+	droplet="$1"
+	new_name="$2"
+	droplet_id=$(instance_id $droplet)
+	if [[ -z $droplet_id ]]; then
+		echo "Droplet $droplet doesn't exist"
+	else
+		result=$(doctl compute droplet-action rename $droplet_id --droplet-name $new_name)
+	fi
+fi

--- a/interact/axiom-rename
+++ b/interact/axiom-rename
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+AXIOM_PATH="$HOME/axiom_contribution/axiom/"
+source "$AXIOM_PATH/interact/includes/vars.sh"
+source "$AXIOM_PATH/interact/includes/functions.sh"
+
+droplet="$1"
+new_name="$2"
+droplet_id=$(instance_id $droplet)
+echo $droplet_id
+result=$(doctl compute droplet-action rename $droplet_id --droplet-name $new_name)
+echo $result

--- a/interact/includes/functions.sh
+++ b/interact/includes/functions.sh
@@ -14,6 +14,13 @@ instance_ip() {
 	instances | jq -r ".[] | select(.name==\"$name\") | .networks.v4[].ip_address"
 }
 
+# takes one argument, name of instance, returns its ID
+instance_id() {
+	name="$1"
+	instances | jq -r ".[] | select(.name==\"$name\") | .id"
+}
+
+
 # takes no arguments, creates an fzf menu
 instance_menu() {
 	instances | jq -r '.[].name' | fzf


### PR DESCRIPTION
Added:
- instance_id function in interact/functions.sh. It's returning id for given droplet name.
- axiom-rename that allows renaming droplets
- axiom-rename reference in README.md

I created axiom-rename to make it possible to rename droplets on the run, so I can mark those that are currently used, but it can be probably useful in other situations as well. I will also create other tool to manage tags so they can also be quite handy in grouping and managing your droplets.
