### PR TITLE
Added axiom-tags to allow creating and management of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ It requires no arguments.
 ## `axiom-scp`
 `axiom-scp` allows copying files between the host and the target machine, wrapping the traditional `scp` command but you can use the machine name instead. For example: `axiom-scp file.txt noyce-14:file.txt` will copy your local file.txt to your `noyce-14` machine.
 
+## `axiom-tags`
+`axiom-tags` allows creating and deleting tags. It also allows assigning and unassigning those tags to specific droplets, so you can group them for better management.
+
 ## `axiom-vpn`
 `axiom-vpn` is used for connecting to a deploy openvpn server (using the deployment script).
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ It requires no arguments.
 `axiom-scp` allows copying files between the host and the target machine, wrapping the traditional `scp` command but you can use the machine name instead. For example: `axiom-scp file.txt noyce-14:file.txt` will copy your local file.txt to your `noyce-14` machine.
 
 ## `axiom-tags`
-`axiom-tags` allows creating and deleting tags. It also allows assigning and unassigning those tags to specific droplets, so you can group them for better management.
+`axiom-tags` allows creating and deleting tags. It also allows assigning those tags to specific droplets, so you can group them for better management.
 
 ## `axiom-vpn`
 `axiom-vpn` is used for connecting to a deploy openvpn server (using the deployment script).

--- a/interact/axiom-tags
+++ b/interact/axiom-tags
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+AXIOM_PATH="$HOME/.axiom"
+source "$AXIOM_PATH/interact/includes/vars.sh"
+source "$AXIOM_PATH/interact/includes/functions.sh"
+
+usage="axiom-tags allows creation and management of tags
+	
+	create - create new tag
+	delete - delete a tag
+	list-tags - list created tags
+	tag - add a tag to a droplet
+	untag - remove a tag from a droplet
+	count - return a number of droplets for a given tag
+	list - return a list of droplets for a given tag"
+create_usage="usage: axiom-tags create <tag_name>"
+delete_usage="usage: axiom-tags delete <tag_name> [-f] [--force]"
+tag_usage="usage: axiom-tags tag <droplet_name> <tag_name>"
+untag_usage="usage: axiom-tags untag <droplet_name> <tag_name>"
+count_usage="usage: axiom-tags count <tag_name>"
+list_usage="usage: axiom-tags list <tag_name>"
+
+function does_tag_exist() {
+	echo $(doctl compute tag list | grep $1)
+}
+
+if [[ $# -eq 0 ]]; then
+	echo "$usage"
+else
+	if [[ "$1" == "create" ]]; then
+		if [[ $# -eq 1 ]]; then
+			echo "$create_usage"
+		else
+			result=$(doctl compute tag create $2)
+		fi
+	elif [[ "$1" == "delete" ]]; then
+		if [[ $# -eq 1 ]]; then
+			echo "$delete_usage"
+		else
+			if [[ $# -eq 3 && ( "$3" == "-f" || "$3" == "--force" ) ]]; then
+				result=$(doctl compute tag delete $2 -f)
+			else
+				result=$(doctl compute tag delete $2)
+			fi
+		fi
+	elif [[ "$1" == "list-tags" ]]; then
+		echo "$(doctl compute tag list)"
+	elif [[ "$1" == "tag" ]]; then
+		if [[ $# -lt 3 ]]; then
+			echo "$tag_usage"
+		else
+			is_existing=$(does_tag_exist $3)
+			if [[ -n $is_existing ]]; then
+				result=$(doctl compute droplet tag $2 --tag-name $3)
+			else
+				echo "Tag $3 doesn't exist"
+			fi
+		fi
+	elif [[ "$1" == "untag" ]]; then
+		if [[ $# -lt 3 ]]; then
+			echo "$untag_usage"
+		else
+			is_existing=$(does_tag_exist $3)
+			if [[ -n $is_existing ]]; then
+				result=$(doctl compute droplet untag $2 --tag-name $3)
+			else
+				echo "Tag $3 doesn't exist"
+			fi
+		fi
+	elif [[ "$1" == "count" ]]; then
+		if [[ $# -eq 1 ]]; then
+			echo "$count_usage"
+		else
+			is_existing=$(does_tag_exist $2)
+			if [[ -n $is_existing ]]; then
+				echo $(doctl compute tag get --no-header --format DropletCount $2)
+			else
+				echo "Tag $2 doesn't exist"
+			fi
+		fi
+	elif [[ "$1" == "list" ]]; then
+		if [[ $# -eq 1 ]]; then
+			echo "$list_usage"
+		else
+			is_existing=$(does_tag_exist $2)
+			if [[ -n $is_existing ]]; then
+				echo "$(doctl compute droplet list --no-header --format Name --tag-name $2)"
+			else
+				echo "Tag $2 doesn't exist"
+			fi
+	
+		fi
+	else
+		echo "$usage"
+	fi
+fi
+
+


### PR DESCRIPTION
I created axiom-tags to facilitate creation and management of tags. You can use them to better group droplets(for example tag a machine that is currently working and can't be used for other tasks). I also added info about axiom-tags in README.md file.
The tool allows you to:
- create new tags with `axiom-tags create`
- delete created tags with `axiom-tags delete`
- list created tags with `axiom-tags list-tags`
- assign tags to droplets with `axiom-tags tag`
- remove tags from droplets with `axiom-tags untag`
- return number of machines with specific tag with `axiom-tags count` - i know that it's a little redundant
- return list of machines with specific tag with `axiom-tags list`

I don't know if I should move every use of `doctl` tool out of axiom-tags file to includes/functions.sh so I didn't do it for now.