### PR TITLE
Select public ip

### DIFF
--- a/interact/includes/functions.sh
+++ b/interact/includes/functions.sh
@@ -11,7 +11,7 @@ instances() {
 # takes one argument, name of instance, returns raw IP address
 instance_ip() {
 	name="$1"
-	instances | jq -r ".[] | select(.name==\"$name\") | .networks.v4[].ip_address"
+	instances | jq -r ".[] | select(.name==\"$name\") | .networks.v4[] | select(.type==\"public\").ip_address"
 }
 
 # takes no arguments, creates an fzf menu
@@ -21,7 +21,7 @@ instance_menu() {
 
 quick_ip() {
 	data="$1"
-	ip=$(echo $droplets | jq -r ".[] | select(.name == \"$name\") | .networks.v4[].ip_address")
+	ip=$(echo $droplets | jq -r ".[] | select(.name == \"$name\") | .networks.v4[] | select(.type==\"public\").ip_address")
 	echo $ip
 }
 
@@ -29,7 +29,7 @@ instance_pretty() {
 	data=$(instances)
 	i=0
 	for f in $(echo $data | jq -r '.[].size.price_monthly'); do new=$(expr $i + $f); i=$new; done
-	(echo "Instance,IP,Region,Memory,\$/M" && echo $data | jq  -r '.[] | [.name, .networks.v4[].ip_address, .region.slug, .size_slug, .size.price_monthly] | @csv' && echo "_,_,Total,\$$i") | sed 's/"//g' | column -t -s, | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
+	(echo "Instance,IP,Region,Memory,\$/M" && echo $data | jq  -r '.[] | [.name, .networks.v4[] | select(.type==\"public\").ip_address, .region.slug, .size_slug, .size.price_monthly] | @csv' && echo "_,_,Total,\$$i") | sed 's/"//g' | column -t -s, | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
 }
 
 # identifies the selected instance/s
@@ -190,8 +190,8 @@ generate_sshconfig() {
 	echo -n "" > $AXIOM_PATH/.sshconfig.new
 
 	for name in $(echo "$droplets" | jq -r '.[].name')
-	do 
-		ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .networks.v4[].ip_address")
+	do
+		ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .networks.v4[] | select(.type==\"public\").ip_address")
 		echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
 	done
 	mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig


### PR DESCRIPTION
Without type==public, private ip was added to .sshconfig and ends up with `Bad configuration option` error.

Tested on:
doctl version 1.45.1-release
doctl version 1.46.0-release