### PR TITLE
Fixing parrot configure.

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -45,7 +45,7 @@ if [ $BASEOS == "Linux" ]; then
 	if [ $OS == "Arch" ] || [ $OS == "ManjaroLinux" ]; then
 		echo -e "${Blue}Congrats, you run arch..."
 		sudo pacman -S fzf packer jq doctl
-	elif [ $OS == "Ubuntu" ] || [ $OS == "Debian" ] || [ $OS == "Linuxmint" ] || [$OS == "Parrot" ]; then
+	elif [ $OS == "Ubuntu" ] || [ $OS == "Debian" ] || [ $OS == "Linuxmint" ] || [ $OS == "Parrot" ]; then
 		sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
 		wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
 		sudo apt-get update && sudo apt-get install fzf git ruby


### PR DESCRIPTION
Parrot install did not work correctly because there was a typo in the configure if statement. Fixed by adding a space.