### PR TITLE
doctl unzip path issue

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -51,17 +51,17 @@ if [ $BASEOS == "Linux" ]; then
 		git clone https://github.com/codingo/Interlace.git /tmp/interlace
 		cd /tmp/interlace && sudo python3 setup.py install
 		sudo apt-get update && sudo apt-get install fzf git ruby
-		wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf doctl.tar.gz && sudo mv doctl /usr/bin
+		wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin
 	elif [ $OS == "Fedora" ]; then
 		sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
 		wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
 		sudo dnf -y update && sudo dnf -y install fzf git
-		wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf doctl.tar.gz && sudo mv doctl /usr/bin
+		wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin
 	elif [ $OS == "UbuntuWSL" ]; then
 		sudo apt-get update && sudo apt-get install fzf git unzip
 		sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
 		wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
-		wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf doctl.tar.gz && sudo mv doctl /usr/bin
+		wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -zxf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin
 	fi
 fi
 


### PR DESCRIPTION
/tmp/doctl.tar.gz           100%[===========================================>]  11.87M  11.5MB/s    in 1.0s

2020-10-20 00:05:54 (11.5 MB/s) - ‘/tmp/doctl.tar.gz’ saved [12450872/12450872]

tar (child): doctl.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2