### PR TITLE
Update amass.json

### DIFF
--- a/modules/amass.json
+++ b/modules/amass.json
@@ -1,4 +1,4 @@
 [{
-	"command":"/usr/bin/amass enum -passive -df input -o output",
+	"command":"/usr/bin/amass enum -df input -o output",
 	"ext":"txt"
 }]


### PR DESCRIPTION
Using the flag -passive amass will not validate DNS information, for example by resolving the subdomains. The flag creates a conflict with other flags (brute-force, active, etc). This flag should be given at run time by the user.