### PR TITLE
Update dalfox installation (bump to v2)

### DIFF
--- a/images/provisioners/full.json
+++ b/images/provisioners/full.json
@@ -164,7 +164,7 @@
         "wget -O /tmp/amass.zip https://github.com/OWASP/Amass/releases/download/v3.11.1/amass_linux_amd64.zip && cd /tmp/ && unzip /tmp/amass.zip && mv /tmp/amass_linux_amd64/amass /usr/bin/amass",
         "/bin/su -l op -c 'mkdir -p /home/op/go/src/github.com/zmap/ && git clone https://github.com/zmap/zdns.git /home/op/go/src/github.com/zmap/zdns  && cd /home/op/go/src/github.com/zmap/zdns/zdns && go build && go install'",
         "echo 'Installing dalfox'",
-        "/bin/su -l op -c 'go get -u github.com/hahwul/dalfox'",
+        "/bin/su -l op -c 'GO111MODULE=on go get -u github.com/hahwul/dalfox/v2'",
         "echo 'Installing gospider'",
         "/bin/su -l op -c 'go get -u github.com/jaeles-project/gospider'",
         "echo 'Increasing ulimit'",


### PR DESCRIPTION
## Change install script
before
```
▶ go get -u github.com/hahwul/dalfox
```

after 
```
▶ GO111MODULE=on go get -u github.com/hahwul/dalfox/v2
```

## Why change it?
> from https://github.com/hahwul/dalfox/discussions/178

When installing with an existing path, the v1.x version of the package is installed intermittently. This was a problem with version management of dalfox, and it was fixed and distributed.
It will now be installed in the latest version without any problems.

## Testing
Install v2
```
▶ GO111MODULE=on go get -u github.com/hahwul/dalfox/v2
```

Run
```
▶ ~/go/bin/dalfox version
v2.3.0
```
