### PR TITLE
Add gobuster modules for axiom scan

### DIFF
--- a/modules/gobuster-dir.json
+++ b/modules/gobuster-dir.json
@@ -1,0 +1,5 @@
+[{
+	"command":"/usr/bin/gobuster dir -q -w input -o output -u ",
+	"ext":"txt"
+}]
+

--- a/modules/gobuster-dns.json
+++ b/modules/gobuster-dns.json
@@ -1,0 +1,4 @@
+[{
+	"command":"/usr/bin/gobuster dns -q -w input -o output -d ",
+	"ext":"txt"
+}]


### PR DESCRIPTION
I'm creating this PR because it's probably useful for other folks as well - I'm using these two modules for gobusting with a fleet. 

Usage looks like 

`axiom-scan <wordlist> -m gobuster_dir -o out.txt https://target.tld` and `axiom-scan <wordlist> -m gobuster_dns -o out.txt target.tld`