### PR TITLE
Fix for Azure build

### DIFF
--- a/interact/account-helpers/azure.sh
+++ b/interact/account-helpers/azure.sh
@@ -62,7 +62,7 @@ if [[ "$ans" == "Y" ]]; then
     read appliance_key 
 fi
 
-data="$(echo "{\"client_id\":\"$client_id\",\"client_secret\":\"$client_secret\",\"tenant_id\":\"$tenant_id\",\"subscription_id\":\"$sub_id\",\"region\":\"$region\",\"resource_group\":\"axiom\",\"provider\":\"azure\",\"default_size\":\"$size\",\"appliance_name\":\"$appliance_name\",\"appliance_key\":\"$appliance_key\",\"appliance_url\":\"$appliance_url\", \"email\":\"$email\",\"use_azure_cli_auth\":$use_azure_cli_auth}")"
+data="$(echo "{\"client_id\":\"$client_id\",\"client_secret\":\"$client_secret\",\"tenant_id\":\"$tenant_id\",\"subscription_id\":\"$sub_id\",\"region\":\"$region\",\"resource_group\":\"axiom\",\"provider\":\"azure\",\"default_size\":\"$size\",\"appliance_name\":\"$appliance_name\",\"appliance_key\":\"$appliance_key\",\"appliance_url\":\"$appliance_url\", \"email\":\"$email\",\"use_azure_cli_auth\":\"$use_azure_cli_auth\"}")"
 
 echo -e "${BGreen}Profile settings below: ${Color_Off}"
 echo $data | jq


### PR DESCRIPTION
Building for azure failed because of a wrongly generated json

```
...
Profile settings below:
{
  "tenant_id": "faf21849-ea4b-496c-81ab-a7870363e7e2",
  "subscription_id": "1531e8b7-2d45-4d6b-8a5c-8691ee33ab26",
  "region": "eastus",
  "resource_group": "axiom",
  "provider": "azure",
  "default_size": "Standard_B1s",
  "appliance_name": "",
  "appliance_key": "",
  "appliance_url": "",
  "email": "f----@-------.com.mx",
  "use_azure_cli_auth": true
}
Press enter if you want to save these to a new profile, type 'r' if you wish to start again.

Please enter your profile name (e.g 'personal', must be all lowercase/no specials)

... <...snipped...> ...

Building image full for provider azure... This can take up to 25 minutes so please be patient!
Ocassionally this will fail, we  don't know why, but it should auto-restart.
**Error reading variables in '/home/azureuser/.axiom/axiom.json': json: cannot unmarshal bool into Go value of type string**

==> Builds finished but no artifacts were created.
Your build failed :( Please take a look at the errors!
This can happen sometimes, if you have a [404] error while using Linode, this is likely because you need to request support for a larger image size to 18GB!
For support, take a screenshot of the last 20 lines and open a issue at https://github.com/pry0cc/axiom/issues
Sometimes just running a build again can work, so please try at least once: 'axiom-build', thanks!
```

So I poked around the code and saw the missing double quotes -->

```
Profile settings below:
{
  "tenant_id": "faf21849-ea4b-496c-81ab-a7870363e7e2",
  "subscription_id": "1531e8b7-2d45-4d6b-8a5c-8691ee33ab26",
  "region": "centalus",
  "resource_group": "axiom",
  "provider": "azure",
  "default_size": "Standard_B1s",
  "appliance_name": "",
  "appliance_key": "",
  "appliance_url": "",
  "email": "f----@-------.com.mx",
  **"use_azure_cli_auth": "true"**
}
Press enter if you want to save these to a new profile, type 'r' if you wish to start again.

... <...snipped...> ...

Building image full for provider azure... This can take up to 25 minutes so please be patient!
Ocassionally this will fail, we  don't know why, but it should auto-restart.
azure-arm: output will be in this color.

==> azure-arm: Running builder ...
==> azure-arm: Getting tokens using client secret
==> azure-arm: Getting tokens using client secret
    azure-arm: Creating Azure Resource Manager (ARM) client ...
```