### PR TITLE
Bugfix axiom-scan: output was not saved when output path is relative path & pwd includes whitespace

### DIFF
--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -157,7 +157,7 @@ split_file() {
     [[ $(expr $lines % $divisor) != 0 ]] && lines_per_file=$(expr $lines_per_file + 1)
     cat "$file" | shuf > "$tmp/split/targets"
 
-    cd "$tmp/split" && split -l $lines_per_file targets && rm targets && cd $start
+    cd "$tmp/split" && split -l $lines_per_file targets && rm targets && cd "$start"
     # Rename "xaa" etc  to 1 2 3 4 5
     i=1
     for f in $(find "$tmp/split/" -type f | tr '/' ' ' | awk '{ print $NF }')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70058709/112512851-1a14fc00-8dd7-11eb-907e-0517842cb107.png)

axiom-scan line 160 made error when output path is relative path & pwd includes whitespace.