### PR TITLE
Fixed Assetnote Wordlist Download

### DIFF
--- a/images/provisioners/full.json
+++ b/images/provisioners/full.json
@@ -87,7 +87,7 @@
         "sudo wget -O /usr/bin/gowitness https://github.com/sensepost/gowitness/releases/download/2.3.0/gowitness-2.3.0-linux-amd64 && sudo chmod +x /usr/bin/gowitness",
         "wget -O /home/op/bin/ffuz https://raw.githubusercontent.com/pry0cc/ffuz/main/ffuz && chmod +x /home/op/bin/ffuz",
         "sudo wget https://raw.githubusercontent.com/xero/figlet-fonts/master/Bloody.flf -O /usr/share/figlet/Bloody.flf",
-        "/bin/su -l op -c 'cd /home/op/lists/assetnote; wget -r --no-parent -R index.html\* https://wordlists-cdn.assetnote.io/data/ -nH'",
+        "mkdir -p /home/op/lists/assetnote; cd /home/op/lists/assetnote; wget -r --no-parent -R 'index.html*' https://wordlists-cdn.assetnote.io/data/ -nH",
         "git clone https://github.com/ProjectAnte/dnsgen /home/op/recon/dnsgen && cd /home/op/recon/dnsgen && pip3 install -r requirements.txt && sudo python3 setup.py install",
         "git clone https://github.com/navisecdelta/EmailGen.git /home/op/recon/emailgen",
         "git clone https://github.com/blark/aiodnsbrute.git /home/op/recon/aiodnsbrute",

--- a/images/provisioners/full.json
+++ b/images/provisioners/full.json
@@ -87,7 +87,7 @@
         "sudo wget -O /usr/bin/gowitness https://github.com/sensepost/gowitness/releases/download/2.3.0/gowitness-2.3.0-linux-amd64 && sudo chmod +x /usr/bin/gowitness",
         "wget -O /home/op/bin/ffuz https://raw.githubusercontent.com/pry0cc/ffuz/main/ffuz && chmod +x /home/op/bin/ffuz",
         "sudo wget https://raw.githubusercontent.com/xero/figlet-fonts/master/Bloody.flf -O /usr/share/figlet/Bloody.flf",
-        "/bin/su -l op -c 'aws s3 sync s3://assetnote-wordlists/data/ ~/lists/assetnote --no-sign-request'",
+        "/bin/su -l op -c 'cd /home/op/lists/assetnote; wget -r --no-parent -R index.html\* https://wordlists-cdn.assetnote.io/data/ -nH'",
         "git clone https://github.com/ProjectAnte/dnsgen /home/op/recon/dnsgen && cd /home/op/recon/dnsgen && pip3 install -r requirements.txt && sudo python3 setup.py install",
         "git clone https://github.com/navisecdelta/EmailGen.git /home/op/recon/emailgen",
         "git clone https://github.com/blark/aiodnsbrute.git /home/op/recon/aiodnsbrute",


### PR DESCRIPTION
Assetnote has decided to update their wordlists download from using S3 sync over to using wget recursively through a CDN. The current patch creates the directory and drops into it to do work. One of the things that I am not fond of is the fact that the directory is called data and there seems to be .json files littered in the directory. It's not terrible, but it could be cleaned a little further. They also only run changes every 30 days, I think it would be good for the system not to update within a 30 day window to decrease their download volumes, however I don't think there is a good way to do this currently. Recommend scheduling updates to axiom every 30 days to be kinder.