### PR TITLE
Update axiom-build

### DIFF
--- a/interact/axiom-build
+++ b/interact/axiom-build
@@ -74,7 +74,7 @@ then
 		time="$seconds seconds"
 	fi
 
-    echo -e "${BGreen}Your build completed successfully in $time! You should run axiom-update && axiom-build weekly to get the latest and greatest updates!" ${Color_Off}"
+    echo -e "${BGreen}Your build completed successfully in $time! You should run axiom-update && axiom-build weekly to get the latest and greatest updates! ${Color_Off}"
     echo -e "${Green}To initialize an instance, run axiom-init${Color_Off}"
 	  "$AXIOM_PATH"/interact/axiom-prune
     "$NOTIFY_CMD" "Axiom Info" "Build completed successfully! 


### PR DESCRIPTION
Typo created an error while displaying info at the end of the building process:

```
Your build completed successfully in 41 minutes! You should run axiom-update && axiom-build weekly to get the latest and greatest updates! 
    echo -e To initialize an instance, run axiom-init
	  /home/kali/.axiom/interact/axiom-prune
    notify Axiom Info Build completed successfully!
```