### PR TITLE
Update axiom-config

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -134,6 +134,39 @@ if [ $BASEOS == "Linux" ]; then
 fi
 
 
+if [ $BASEOS == "Mac" ]; then
+         whereis brew
+  if [ ! $? -eq 0 ] || [[ ! -z ${AXIOM_FORCEBREW+x} ]]; then
+         echo -e "${Blue}Installing brew...${Color_Off}"
+         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  else
+         echo -e "${Blue}Checking for brew... already installed, skipping installation.${Color_Off}"
+         echo -e "${Blue}    Note: You can force brew installation by running${Color_Off}"
+         echo -e '    $ AXIOM_FORCEBREW=yes $HOME/.axiom/interact/axiom-configure'
+  fi
+         echo -e "${Blue}Installing doctl...${Color_Off}"
+         brew install doctl
+         echo -e "${Blue}Installing go...${Color_Off}"
+         brew install golang
+         echo -e "${Blue}Installing ibmcloud cli...${Color_Off}"
+         curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
+         echo -e "${Blue}Installing jq...${Color_Off}"
+         brew install jq
+         echo -e "${Blue}Installing coreutils...${Color_Off}"
+         brew install coreutils
+         echo -e "${Blue}Installing packer...${Color_Off}"
+         mkdir -p $(go env GOPATH)/src/github.com/hashicorp && cd $_
+         sudo rm -r packer/ ; git clone https://github.com/hashicorp/packer.git
+         echo -e "${Blue}Installing Python3...${Color_Off}"
+         brew install python3
+         cd packer
+         make dev
+         export PATH=$PATH:$(go env GOPATH)/bin
+         source ~/.bash_profile
+         mkdir -p "${HOME}/.ssh/sockets"
+fi
+
+
 #install go
 if ! [ -x "$(command -v go)" ]; then
        echo -e "${Blue}It looks like go is not installed, would you like to install it now${Color_Off}"
@@ -166,37 +199,6 @@ if ! [ -x "$(command -v go)" ]; then
    done
 fi
 
-if [ $BASEOS == "Mac" ]; then
-         whereis brew
-  if [ ! $? -eq 0 ] || [[ ! -z ${AXIOM_FORCEBREW+x} ]]; then
-         echo -e "${Blue}Installing brew...${Color_Off}"
-         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  else
-         echo -e "${Blue}Checking for brew... already installed, skipping installation.${Color_Off}"
-         echo -e "${Blue}    Note: You can force brew installation by running${Color_Off}"
-         echo -e '    $ AXIOM_FORCEBREW=yes $HOME/.axiom/interact/axiom-configure'
-  fi
-         echo -e "${Blue}Installing doctl...${Color_Off}"
-         brew install doctl
-         echo -e "${Blue}Installing go...${Color_Off}"
-         brew install golang
-         echo -e "${Blue}Installing ibmcloud cli...${Color_Off}"
-         curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
-         echo -e "${Blue}Installing jq...${Color_Off}"
-         brew install jq
-         echo -e "${Blue}Installing coreutils...${Color_Off}"
-         brew install coreutils
-         echo -e "${Blue}Installing packer...${Color_Off}"
-         mkdir -p $(go env GOPATH)/src/github.com/hashicorp && cd $_
-         sudo rm -r packer/ ; git clone https://github.com/hashicorp/packer.git
-         echo -e "${Blue}Installing Python3...${Color_Off}"
-         brew install python3
-         cd packer
-         make dev
-         export PATH=$PATH:$(go env GOPATH)/bin
-         source ~/.bash_profile
-         mkdir -p "${HOME}/.ssh/sockets"
-fi
 
 if [ ! -d $AXIOM_PATH ]; then
     echo -e "${Blue}Installing axiom scripts...${Color_Off}"

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -71,12 +71,12 @@ if [ $BASEOS == "Linux" ]; then
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"
-        wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
+        wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip
         echo -e "${Blue}Installing Interlace...${Color_Off}"
         git clone https://github.com/codingo/Interlace.git /tmp/interlace
         cd /tmp/interlace && sudo python3 setup.py install
         echo -e "${Blue}Installing doctl...${Color_Off}"
-        wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl
+        wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl && rm /tmp/doctl.tar.gz
         echo -e "${Blue}Installing ibmcloud cli...${Color_Off}"
         curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
         echo -e "${Blue}Installing azure az...${Color_Off}"
@@ -98,23 +98,23 @@ if [ $BASEOS == "Linux" ]; then
 		    echo -e "${Blue}Installing jq...${Color_Off}"
 		    sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
 		    echo -e "${Blue}Installing packer...${Color_Off}"
-		    wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
+		    wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip
 		    echo -e "${Blue}Installing other repo deps...${Color_Off}"
 		    sudo dnf -y update && sudo dnf -y install fzf git
 		    echo -e "${Blue}Installing doctl...${Color_Off}"
-		    wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl
+		    wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl && rm /tmp/doctl.tar.gz
 	elif [ $OS == "UbuntuWSL" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
         sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"
-        wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/
+        wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip
         echo -e "${Blue}Installing Interlace...${Color_Off}"
         git clone https://github.com/codingo/Interlace.git /tmp/interlace
         cd /tmp/interlace && sudo python3 setup.py install
         echo -e "${Blue}Installing doctl...${Color_Off}"
-        wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl
+        wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl && rm /tmp/doctl.tar.gz
         echo -e "${Blue}Installing ibmcloud cli...${Color_Off}"
         curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
         echo -e "${Blue}Installing azure az...${Color_Off}"
@@ -179,6 +179,7 @@ if ! [ -x "$(command -v go)" ]; then
        echo -e "${Blue}Installing Golang${Color_Off}"
        wget https://golang.org/dl/go1.14.4.linux-amd64.tar.gz
        sudo tar -C /usr/local -xzf go1.14.4.linux-amd64.tar.gz 
+       rm go1.14.4.linux-amd64.tar.gz
        mkdir -p "${HOME}/go"
        export GOROOT=/usr/local/go/
        export GOPATH=$HOME/go

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -101,6 +101,8 @@ if [ $BASEOS == "Linux" ]; then
 		    wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip
 		    echo -e "${Blue}Installing doctl...${Color_Off}"
 		    wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl && rm /tmp/doctl.tar.gz
+            echo -e "${Blue}Installing gowitness...${Color_Off}"
+            sudo wget -O /usr/bin/gowitness https://github.com/sensepost/gowitness/releases/download/2.2.0/gowitness-2.2.0-linux-amd64 && sudo chmod +x /usr/bin/gowitness
 	elif [ $OS == "UbuntuWSL" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
         sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -67,7 +67,7 @@ if [ $BASEOS == "Linux" ]; then
         sudo pacman -S fzf packer jq doctl
     elif [ $OS == "Ubuntu" ] || [ $OS == "Debian" ] || [ $OS == "Linuxmint" ] || [ $OS == "Parrot" ] || [ $OS == "Kali" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
-        sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools git unzip xsltproc bc uuid-runtime rsync
+        sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime rsync
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"
@@ -105,7 +105,7 @@ if [ $BASEOS == "Linux" ]; then
 		    wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl
 	elif [ $OS == "UbuntuWSL" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
-        sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools git unzip xsltproc bc uuid-runtime
+        sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -177,9 +177,9 @@ if ! [ -x "$(command -v go)" ]; then
        yes)
 
        echo -e "${Blue}Installing Golang${Color_Off}"
-       wget https://golang.org/dl/go1.14.4.linux-amd64.tar.gz
-       sudo tar -C /usr/local -xzf go1.14.4.linux-amd64.tar.gz 
-       rm go1.14.4.linux-amd64.tar.gz
+       wget https://golang.org/dl/go1.16.3.linux-amd64.tar.gz
+       sudo tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz 
+       rm go1.16.3.linux-amd64.tar.gz
        mkdir -p "${HOME}/go"
        export GOROOT=/usr/local/go/
        export GOPATH=$HOME/go

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -94,13 +94,11 @@ if [ $BASEOS == "Linux" ]; then
 
 	elif [ $OS == "Fedora" ]; then
       	echo -e "${Blue}Installing other repo deps...${Color_Off}"
-		    sudo dnf update && sudo dnf install bc fzf git rubypick python3-pip curl net-tools unzip util-linux
+		    sudo dnf update && sudo dnf -y install bc fzf git rubypick python3-pip curl net-tools unzip util-linux
 		    echo -e "${Blue}Installing jq...${Color_Off}"
 		    sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
 		    echo -e "${Blue}Installing packer...${Color_Off}"
 		    wget -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip
-		    echo -e "${Blue}Installing other repo deps...${Color_Off}"
-		    sudo dnf -y update && sudo dnf -y install fzf git
 		    echo -e "${Blue}Installing doctl...${Color_Off}"
 		    wget -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.45.0/doctl-1.45.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl && rm /tmp/doctl.tar.gz
 	elif [ $OS == "UbuntuWSL" ]; then


### PR DESCRIPTION
After a review of the `axiom-config` script there were opportunities to correct parts of the script. In particular this commit contains the following:

- The Ubuntu and WSL `apt-get install` for dependencies had `git` repeated
- Move the install of Go lower to allow macOS to `brew install go`, since currently it installs the Linux version of Go on macOS
- `rm` downloaded archives to save on space post install
- The version of Go to be installed is now specified to be 1.16.3 from 1.14.4
- Fedora has a duplicate `dnf install` for fzf and git. Also added `-y` flag for install
- Install `gowitness` on Fedora

Please let me know of any further changes you might like me to make. 