### PR TITLE
Added sudo to naabu and handler for blank input

### DIFF
--- a/modules/naabu.json
+++ b/modules/naabu.json
@@ -1,4 +1,4 @@
 [{
-	"command":"cat input | /home/op/go/bin/naabu -o output",
+	"command":"[ ! -s input ] && exit 1; cat input | sudo /home/op/go/bin/naabu -o output",
 	"ext":"txt"
 }]


### PR DESCRIPTION
unlike nmap, naabu will not exit if an empty file is cat'd into it.

Plus it needs to run with sudo to better support half open connections like nmap

It would be nice if axiom-scan also did not send empty files to instances, but I haven't figured out how to change that... yet.