### PR TITLE
fixed module issue with tomnomnom's gf

### DIFF
--- a/images/provisioners/full.json
+++ b/images/provisioners/full.json
@@ -222,7 +222,7 @@
         "/bin/su -l root -c 'rm -r /home/op/go/src/'",
         "/bin/su -l root -c 'apt-get clean'",
         "echo 'Installing gf'",
-        "/bin/su -l op -c 'go get -u github.com/tomnomnom/gf'",
+        "/bin/su -l op -c 'GO111MODULE=off go get -u github.com/tomnomnom/gf'",
         "echo \"The password for user op is: {{ user `op_random_password` }}\"",
         "echo \"CgpDb25ncmF0dWxhdGlvbnMsIHlvdXIgYnVpbGQgaXMgYWxtb3N0IGRvbmUhCgogICAgICAgICAgICAgYXhpb20gaXMgc3BvbnNvcmVkIGJ5Li4uCl9fX18gICAgICAgICAgICAgICAgICAgICAgIF8gXyAgICAgICAgX19fX18uICAgICAgICAgXyBfCi8gX19ffCAgX19fICBfX18gXyAgIF8gXyBfXyhfKSB8XyBfICAgfF8gICBffCBfXyBfXyBfKF8pIHxfX18KXF9fXyBcIC8gXyBcLyBfX3wgfCB8IHwgJ19ffCB8IF9ffCB8IHwgfHwgfHwgJ19fLyBfYCB8IHwgLyBfX3wKIF9fXykgfCAgX18vIChfX3wgfF98IHwgfCAgfCB8IHxffCB8X3wgfHwgfHwgfCB8IChffCB8IHwgXF9fIFwKfF9fX18vIFxfX198XF9fX3xcX18sX3xffCAgfF98XF9ffFxfXywgfHxffHxffCAgXF9fLF98X3xffF9fXy8KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHxfX18vCgpSZWFkIHRoZXNlIHdoaWxlIHlvdSdyZSB3YWl0aW5nIHRvIGdldCBzdGFydGVkIDopCgogICAgLSBRdWlja3N0YXJ0IEd1aWRlOiBodHRwczovL2dpdGh1Yi5jb20vcHJ5MGNjL2F4aW9tL3dpa2kvQS1RdWlja3N0YXJ0LUd1aWRlCiAgICAtIENoZWF0c2hlZXQ6IGh0dHBzOi8vZ2l0aHViLmNvbS9wcnkwY2MvYXhpb20vd2lraS9DaGVhdHNoZWV0CiAgICAtIEZsZWV0czogaHR0cHM6Ly9naXRodWIuY29tL3ByeTBjYy9heGlvbS93aWtpL0ZsZWV0cyAgICAgCiAgICAtIFNjYW5zOiBodHRwczovL2dpdGh1Yi5jb20vcHJ5MGNjL2F4aW9tL3dpa2kvU2NhbnMKCgo=\" | base64 -d",
         "touch /home/op/.profile",

--- a/images/provisioners/reconftw.json
+++ b/images/provisioners/reconftw.json
@@ -243,7 +243,7 @@
         "/bin/su -l root -c 'rm -r /home/op/go/src/'",
         "/bin/su -l root -c 'apt-get clean'",
         "echo 'Installing gf'",
-        "/bin/su -l op -c 'go get -u github.com/tomnomnom/gf'",
+        "/bin/su -l op -c 'GO111MODULE=off go get -u github.com/tomnomnom/gf'",
         "echo \"The password for user op is: {{ user `op_random_password` }}\"",
         "echo \"CgpDb25ncmF0dWxhdGlvbnMsIHlvdXIgYnVpbGQgaXMgYWxtb3N0IGRvbmUhCgogICAgICAgICAgICAgYXhpb20gaXMgc3BvbnNvcmVkIGJ5Li4uCl9fX18gICAgICAgICAgICAgICAgICAgICAgIF8gXyAgICAgICAgX19fX18uICAgICAgICAgXyBfCi8gX19ffCAgX19fICBfX18gXyAgIF8gXyBfXyhfKSB8XyBfICAgfF8gICBffCBfXyBfXyBfKF8pIHxfX18KXF9fXyBcIC8gXyBcLyBfX3wgfCB8IHwgJ19ffCB8IF9ffCB8IHwgfHwgfHwgJ19fLyBfYCB8IHwgLyBfX3wKIF9fXykgfCAgX18vIChfX3wgfF98IHwgfCAgfCB8IHxffCB8X3wgfHwgfHwgfCB8IChffCB8IHwgXF9fIFwKfF9fX18vIFxfX198XF9fX3xcX18sX3xffCAgfF98XF9ffFxfXywgfHxffHxffCAgXF9fLF98X3xffF9fXy8KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHxfX18vCgpSZWFkIHRoZXNlIHdoaWxlIHlvdSdyZSB3YWl0aW5nIHRvIGdldCBzdGFydGVkIDopCgogICAgLSBRdWlja3N0YXJ0IEd1aWRlOiBodHRwczovL2dpdGh1Yi5jb20vcHJ5MGNjL2F4aW9tL3dpa2kvQS1RdWlja3N0YXJ0LUd1aWRlCiAgICAtIENoZWF0c2hlZXQ6IGh0dHBzOi8vZ2l0aHViLmNvbS9wcnkwY2MvYXhpb20vd2lraS9DaGVhdHNoZWV0CiAgICAtIEZsZWV0czogaHR0cHM6Ly9naXRodWIuY29tL3ByeTBjYy9heGlvbS93aWtpL0ZsZWV0cyAgICAgCiAgICAtIFNjYW5zOiBodHRwczovL2dpdGh1Yi5jb20vcHJ5MGNjL2F4aW9tL3dpa2kvU2NhbnMKCgo=\" | base64 -d",
         "touch /home/op/.profile",


### PR DESCRIPTION
Since the Go src tree is deleted during provisioning and a newer Go version is used, a simple "go get" will not d/l the necessary files for shell completion. This results in nasty errors when logging in to the servers like 
`/home/op/.zshrc:source:114: no such file or directory: /home/op/go/src/github.com/tomnomnom/gf/gf-completion.zsh`

To actually download the source to the correct directory the `GO111MODULE` env variable needs to be set to `off`. 

This is fixed in full.json and reconftw.json with this PR. 