### PR TITLE
Naabu with nmap support

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -67,7 +67,7 @@ if [ $BASEOS == "Linux" ]; then
         sudo pacman -S fzf packer jq doctl
     elif [ $OS == "Ubuntu" ] || [ $OS == "Debian" ] || [ $OS == "Linuxmint" ] || [ $OS == "Parrot" ] || [ $OS == "Kali" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
-        sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime rsync
+        sudo apt-get update && sudo apt-get install mmv fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime rsync
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -64,7 +64,7 @@ if [ $BASEOS == "Linux" ]; then
 
     if [ $OS == "Arch" ] || [ $OS == "ManjaroLinux" ]; then
         echo -e "${Blue}Congrats, you run arch..."
-        sudo pacman -S fzf packer jq doctl
+        sudo pacman -S fzf packer jq doctl mmv
     elif [ $OS == "Ubuntu" ] || [ $OS == "Debian" ] || [ $OS == "Linuxmint" ] || [ $OS == "Parrot" ] || [ $OS == "Kali" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
         sudo apt-get update && sudo apt-get install mmv fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime rsync
@@ -94,7 +94,7 @@ if [ $BASEOS == "Linux" ]; then
 
 	elif [ $OS == "Fedora" ]; then
       	echo -e "${Blue}Installing other repo deps...${Color_Off}"
-		    sudo dnf update && sudo dnf -y install bc fzf git rubypick python3-pip curl net-tools unzip util-linux
+		    sudo dnf update && sudo dnf -y mmv install bc fzf git rubypick python3-pip curl net-tools unzip util-linux
 		    echo -e "${Blue}Installing jq...${Color_Off}"
 		    sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
 		    echo -e "${Blue}Installing packer...${Color_Off}"
@@ -105,7 +105,7 @@ if [ $BASEOS == "Linux" ]; then
             sudo wget -O /usr/bin/gowitness https://github.com/sensepost/gowitness/releases/download/2.2.0/gowitness-2.2.0-linux-amd64 && sudo chmod +x /usr/bin/gowitness
 	elif [ $OS == "UbuntuWSL" ]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
-        sudo apt-get update && sudo apt-get install fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime
+        sudo apt-get update && sudo apt-get install mmv fzf git ruby python3-pip curl net-tools unzip xsltproc bc uuid-runtime
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"
@@ -159,6 +159,8 @@ if [ $BASEOS == "Mac" ]; then
          sudo rm -r packer/ ; git clone https://github.com/hashicorp/packer.git
          echo -e "${Blue}Installing Python3...${Color_Off}"
          brew install python3
+         echo -e "${Blue}Installing MMV...${Color_Off}"
+         brew install mmv
          cd packer
          make dev
          export PATH=$PATH:$(go env GOPATH)/bin

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -246,9 +246,9 @@ merge_output() {
         fi
          if [[ "$module" == "naabu-nmap" ]]; then
             echo "Merging naabu and nmap output"
-            cd $output
+            cd $outfile
             mmv '*.*.~*~' '#1#3.#2'
-            cat $output/*.txt | sort -u > $outfile/final_naabu.txt
+            cat $outfile/*.txt | sort -u > $outfile/final_naabu.txt
             echo "Mode set to XML.. Merging Nmap XML output..."
             "$AXIOM_PATH/interact/merge-xml.py" -d "$outfile/output" -o "$outfile/final_nmap.xml" >> /dev/null
             rm -rf "$outfile/naabu*"

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -251,8 +251,8 @@ merge_output() {
             cat $outfile/*.txt | sort -u > $outfile/final_naabu.txt
             echo "Merging Nmap XML output..."
             "$AXIOM_PATH/interact/merge-xml.py" -d "$outfile" -o "$outfile/final_nmap.xml" >> /dev/null
-            rm -rf "$outfile/naabu*"
-            rm -rf "$outfile/nmap*"
+            rm -rf $outfile/naabu*
+            rm -rf $outfile/nmap*
             echo -e "${Green}Done: '${Blue}Merging both naabu ouput and nmap${Color_Off}'"
         fi
     fi

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -229,7 +229,39 @@ merge_output() {
             mv $tmp/merge "$outfile"
         else
            mkdir "$tmp/merge/output/"
-           mmv -a "$tmp/output/*/*" "$tmp/merge/output/#2"
+           cd $tmp/output
+           for pathname in `find . -type f -follow -print`; do
+
+            # create destination pathname
+            dest="$tmp/merge/${pathname#*/*/}"
+            dir=`dirname $dest`
+
+            # create directories
+            if [[ ! -f "$dir" ]]
+            then
+                mkdir -p $dir
+            fi
+
+            z=0;
+            if [[ $dest =~ "." ]]; 
+            then
+                extension=".${dest##*.}"
+                filename="${dest%.*}"
+            else
+                extension=""
+                filename="${dest%.*}"  
+            fi
+            
+            while [ -e "$dest" ]; do
+                # destination name exists, remove backup number from end of
+                # pathname and replace with next one in the sequence
+                z=$(( z + 1 ))
+                dest="${filename}${z}${extension}" 
+            done
+            cp "$pathname" "$dest"
+          done
+
+
            rm -rf "$outfile"
            mv $tmp/merge/output "$outfile"
         fi

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -246,11 +246,13 @@ merge_output() {
         fi
          if [[ "$module" == "naabu-nmap" ]]; then
             echo "Merging naabu and nmap output"
-            cd $tmp/output/
+            cd $output
             mmv '*.*.~*~' '#1#3.#2'
-            cat $tmp/output/*.txt | sort -u > $outfile/naabu.txt
+            cat $output/*.txt | sort -u > $outfile/final_naabu.txt
             echo "Mode set to XML.. Merging Nmap XML output..."
-            "$AXIOM_PATH/interact/merge-xml.py" -d "$tmp/output" -o "$outfile/nmap.xml" >> /dev/null
+            "$AXIOM_PATH/interact/merge-xml.py" -d "$outfile/output" -o "$outfile/final_nmap.xml" >> /dev/null
+            rm -rf "$outfile/naabu*"
+            rm -rf "$outfile/nmap*"
             echo -e "${Green}Done: '${Blue}Merging both naabu ouput and nmap${Color_Off}'"
         fi
     fi

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -244,6 +244,15 @@ merge_output() {
             gowitness merge --input-path $tmp/ -o gowitness.sqlite3
             echo -e "${Green}RUN: '${Blue}gowitness -D gowitness.sqlite3 -P screenshots report serve${Color_Off}' for reporting"
         fi
+         if [[ "$module" == "naabu-nmap" ]]; then
+            echo "Merging naabu and nmap output"
+            cd $tmp/output/
+            mmv '*.*.~*~' '#1#3.#2'
+            cat $tmp/output/*.txt | sort -u > $outfile/naabu.txt
+            echo "Mode set to XML.. Merging Nmap XML output..."
+            "$AXIOM_PATH/interact/merge-xml.py" -d "$tmp/output" -o "$outfile/nmap.xml" >> /dev/null
+            echo -e "${Green}Done: '${Blue}Merging both naabu ouput and nmap${Color_Off}'"
+        fi
     fi
 }
 

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -228,11 +228,8 @@ merge_output() {
             rm -rf "$outfile"
             mv $tmp/merge "$outfile"
         else
-           if [ $BASEOS == "Linux" ]; then 
-            cp -r --backup=t $tmp/output/*/* $tmp/merge
-           else
-            cp -r $tmp/output/*/* $tmp/merge
-           fi
+           mkdir "$tmp/merge/output/"
+           mmv -a "$tmp/output/*/*" "$tmp/merge/output/#2"
            rm -rf "$outfile"
            mv $tmp/merge/output "$outfile"
         fi
@@ -246,8 +243,6 @@ merge_output() {
         fi
          if [[ "$module" == "naabu-nmap" ]]; then
             echo "Merging naabu and nmap output"
-            cd $outfile
-            mmv '*.*.~*~' '#1#3.#2'
             cat $outfile/*.txt | sort -u > $outfile/final_naabu.txt
             echo "Merging Nmap XML output..."
             "$AXIOM_PATH/interact/merge-xml.py" -d "$outfile" -o "$outfile/final_nmap.xml" >> /dev/null

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -249,8 +249,8 @@ merge_output() {
             cd $outfile
             mmv '*.*.~*~' '#1#3.#2'
             cat $outfile/*.txt | sort -u > $outfile/final_naabu.txt
-            echo "Mode set to XML.. Merging Nmap XML output..."
-            "$AXIOM_PATH/interact/merge-xml.py" -d "$outfile/output" -o "$outfile/final_nmap.xml" >> /dev/null
+            echo "Merging Nmap XML output..."
+            "$AXIOM_PATH/interact/merge-xml.py" -d "$outfile" -o "$outfile/final_nmap.xml" >> /dev/null
             rm -rf "$outfile/naabu*"
             rm -rf "$outfile/nmap*"
             echo -e "${Green}Done: '${Blue}Merging both naabu ouput and nmap${Color_Off}'"

--- a/modules/naabu-nmap.json
+++ b/modules/naabu-nmap.json
@@ -1,0 +1,4 @@
+[{
+    "command":"[ ! -s input ] && exit 1; mkdir output ;cat input | sudo /home/op/go/bin/naabu -o output/naabu.txt",
+    "ext":""
+}]


### PR DESCRIPTION
When you run nmap with naabu, You cannot download the XML output as only one extension is allowed. This module is registered as a directory extension, So it could get all files. The Nmap output should be placed in the output directory and it automatically processes the backups created by cp while merging with `mmv` and creating a sorted list of naabu ports, Nmap merged XML and Nmap merged output.


Example
```bash 
axiom-scan ~/check.txt -m naabu-nmap -p - -rate 10000 -c 50 -nmap-cli $'\"nmap -sV -A -T4 -oX output/nmap.xml\"' -o out/
```