### PR TITLE
axiom-orgalorg, an experimental new aixom-exec

### DIFF
--- a/interact/axiom-execx
+++ b/interact/axiom-execx
@@ -84,7 +84,7 @@ executeorgalorg() {
 if [[ $stdin = 1 ]]; then
 if [ -p /dev/stdin ]; then
   echo "Data was piped to this script!"
-  orgalorg -w -y -o "$tmp/hosts" -i /dev/stdin -C bash 
+  orgalorg -w -y -o "$tmp/hosts" -i /dev/stdin -C /bin/zsh 
   exit 1
  else
   echo "No input given!"

--- a/interact/axiom-execx
+++ b/interact/axiom-execx
@@ -114,7 +114,6 @@ parse_params() {
       command="${2}"
       shift
       ;;
-    -?*) die "Unknown option: $1" ;;
     *) break ;;
     esac
     shift

--- a/interact/axiom-execx
+++ b/interact/axiom-execx
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+AXIOM_PATH="$HOME/.axiom"
+source "$AXIOM_PATH/interact/includes/vars.sh"
+source "$AXIOM_PATH/interact/includes/functions.sh"
+source "$AXIOM_PATH/interact/includes/system-notification.sh"
+begin=$(date +%s)
+rm -r $HOME/.ssh/sockets > /dev/null 2>&1
+start="$(pwd)"
+BASEOS="$(uname)"
+
+setup_colors() {
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+  else
+    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+  fi
+}
+
+setuptools() {
+# install orgalorg and gee
+if ! type "orgalorg" > /dev/null; then
+go get github.com/reconquest/orgalorg
+fi
+if ! type "gee" > /dev/null; then
+GO111MODULE=on go get -v github.com/hahwul/gee
+fi
+}
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+function usage() {
+    cat << EOF
+    Usage: Experimental axiom-exec (axiom-execx)
+    -C|--Command               Execute command across fleet
+    -l|--instances             List of axiom instances to execute on, must be wrapped in double quotes (Defaults to ~/.axiom/selected.conf)
+    -s|--stdin                 Take commands from STDIN
+    -v|--verbose               Increase verbosity
+    -h|--help                  Display this help menu
+EOF
+}
+
+msg() {
+  echo >&2 -e "${1-}"
+}
+
+die() {
+  local msg=$1
+  local code=${2-1} # default exit status 1
+  msg "$msg"
+  exit "$code"
+}
+
+tmpfiles() {
+# make tmp files to store data
+uid="execx+$(date +%s)"
+tmp="$AXIOM_PATH/tmp/$uid"
+mkdir -p "$tmp/input"
+mkdir -p "$tmp/split"
+mkdir -p "$tmp/output"
+mkdir -p "$tmp/logs"
+}
+
+generateSSHfile() {
+# take instances in axiom select or from command line and select them
+if [[ $selected = 1 ]]; then
+  for i in $(cat "$AXIOM_PATH/selected.conf");
+  do instance_ip $i | tee -a "$tmp/ips" &>/dev/null;  done
+ cat "$tmp/ips" | sed -e 's/^/op@/' | sed  s/$/:2266/ | tee -a "$tmp/hosts" &>/dev/null
+else
+  axiom-select $instances
+  for i in $(cat "$AXIOM_PATH/selected.conf");
+  do instance_ip $i | tee -a "$tmp/ips" &>/dev/null;  done
+  cat "$tmp/ips" | sed -e 's/^/op@/' | sed  s/$/:2266/ | tee -a "$tmp/hosts" &>/dev/null
+fi
+}
+
+executeorgalorg() {
+if [[ $stdin = 1 ]]; then
+if [ -p /dev/stdin ]; then
+  echo "Data was piped to this script!"
+  orgalorg -w -y -o "$tmp/hosts" -i /dev/stdin -C bash 
+  exit 1
+ else
+  echo "No input given!"
+fi fi
+
+if [[ $stdin = 0 ]]; then
+ orgalorg -w -y -o "$tmp/hosts" -C $command
+fi
+}
+
+parse_params() {
+  # default values of variables 
+  stdin=0
+  selected=1
+
+  while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -s | --stdin) stdin=1 ;;
+    -i | --instances) selected=0 instances="${2-}"
+    shift # past argument
+    shift # past value
+    ;; # provided instances must be wrapped in double quotes
+    -C | --Command) # pass commands to orgalorg 
+      command="${2}"
+      shift
+      ;;
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  args=("$@")
+
+  # check required params and arguments
+
+if [[ -z "${command-}" && "$stdin" != 1 ]] ; 
+then 
+echo "You must supply a command in line with -C or from stdin with --stdin" 
+usage
+exit 1
+fi
+
+return 0
+}
+
+parse_params "$@"
+setup_colors
+
+# script logic here
+setuptools
+tmpfiles
+generateSSHfile
+executeorgalorg
+
+echo -e "${BGreen}Output saved to '${Blue}$outfile${BGreen}'! Local logs saved to '${Blue}$AXIOM_PATH/tmp/$uid${BGreen}'! ${BGreen}Remote logs saved to '${Blue}/home/op/scan/$uid${BGreen}'!"

--- a/interact/axiom-execx
+++ b/interact/axiom-execx
@@ -38,10 +38,11 @@ function usage() {
     cat << EOF
     Usage: Experimental axiom-exec (axiom-execx)
     -C|--Command               Execute command across fleet
-    -l|--instances             List of axiom instances to execute on, must be wrapped in double quotes (Defaults to ~/.axiom/selected.conf)
+    -i|--instances             List of axiom instances to execute on, must be wrapped in double quotes (Defaults to ~/.axiom/selected.conf)
     -s|--stdin                 Take commands from STDIN
     -v|--verbose               Increase verbosity
     -h|--help                  Display this help menu
+    -l|--serial                Execute commands in serial.
 EOF
 }
 

--- a/interact/axiom-execx
+++ b/interact/axiom-execx
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+
+###################################################################
+# Title	: axiom-execx                                                                                             
+# About	: This is just a simple (read poorly-written) wrapper for two great tools, orgalorg (https://github.com/reconquest/orgalorg), and gee (https://github.com/hahwul/gee).
+# orgalorg is doing most of the heavy lifting. For more details on orgalorg visit the github or run orgalorg -h for the manual.                                                                                 
+# The reason for axiom-execx was to create a more reliable axiom-exec (https://github.com/pry0cc/axiom/blob/master/interact/axiom-exec), that had better variable expansion and execution control.
+# In addition to a more reliable axiom-exec, orgalorg also includes upload and download features, read the orgalorg --help page for more info.
+#
+# Examples: 
+# Taking a file of commands and executing them in serial `axiom-execx -s commands -l`
+# Executing commands from STDIN: `cat commands | axiom-execx --stdin`
+# Execute commands listed from command line `axiom-execx -C "id ; whoami ; hostname"`
+# Running commands against a specifc set of axiom instances or fleet: `axiom-execx -C id -i "jepsen01 jepsen02 jepsen03"`
+# 
+# Author : 0xtavian                                                
+# Github : https://github.com/0xtavian                                           
+###################################################################
+
 AXIOM_PATH="$HOME/.axiom"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 source "$AXIOM_PATH/interact/includes/functions.sh"
@@ -12,13 +30,13 @@ setup_colors() {
   if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
     NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
   else
-    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+   NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
   fi
 }
 
 setuptools() {
 # install orgalorg and gee
-if ! type "orgalorg" > /dev/null; then
+if ! type "orgalorg"  > /dev/null; then
 go get github.com/reconquest/orgalorg
 fi
 if ! type "gee" > /dev/null; then
@@ -37,13 +55,21 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 function usage() {
     cat << EOF
     Usage: Experimental axiom-exec (axiom-execx)
+    Examples:
+     Execute commands from a file, in serial mode : axiom-execx -s commands.txt -l
+     Execute commands from STDIN :  cat commands.txt | axiom-execx --stdin
+     From command line : axiom-execx -C "id ; whoami ; hostname"
+     Against a specifc set of axiom instances or fleet : axiom-execx -C id -i "jepsen01 jepsen02 jepsen03"
+     orgalorg --help for more info 
+   
     -C|--Command               Execute command across fleet
     -i|--instances             List of axiom instances to execute on, must be wrapped in double quotes (Defaults to ~/.axiom/selected.conf)
-    -s|--stdin                 Take commands from STDIN
+    -s|--stdin                 Take commands from STDIN or from a file
     -v|--verbose               Increase verbosity
     -h|--help                  Display this help menu
     -l|--serial                Execute commands in serial.
 EOF
+exit 
 }
 
 msg() {
@@ -88,7 +114,7 @@ if [ -p /dev/stdin ]; then
   orgalorg -w -y -o "$tmp/hosts" -i /dev/stdin -C /bin/zsh 
   exit 1
  else
-  echo "No input given!"
+  orgalorg -w -y -o "$tmp/hosts" -i $command -C /bin/zsh 
 fi fi
 
 if [[ $stdin = 0 ]]; then
@@ -104,16 +130,20 @@ parse_params() {
   while :; do
     case "${1-}" in
     -h | --help) usage ;;
+    -l | --serial) ;;            
     -v | --verbose) set -x ;;
-    -s | --stdin) stdin=1 ;;
+    -s | --stdin) stdin=1
+    command="${2-}"
+    shift # past argument
+    ;;
     -i | --instances) selected=0 instances="${2-}"
     shift # past argument
-    shift # past value
     ;; # provided instances must be wrapped in double quotes
     -C | --Command) # pass commands to orgalorg 
-      command="${2}"
+      command="${2-}"
       shift
       ;;
+    -?*) die "Unknown option: $1" ;;
     *) break ;;
     esac
     shift
@@ -123,7 +153,7 @@ parse_params() {
 
   # check required params and arguments
 
-if [[ -z "${command-}" && "$stdin" != 1 ]] ; 
+if [[ -z "$command" && "$stdin" != 1 ]] ; 
 then 
 echo "You must supply a command in line with -C or from stdin with --stdin" 
 usage

--- a/interact/axiom-orgalorg
+++ b/interact/axiom-orgalorg
@@ -9,10 +9,10 @@
 # In addition to a more reliable axiom-exec, orgalorg also includes upload and download features, read the orgalorg --help page for more info.
 #
 # Examples: 
-# Taking a file of commands and executing them in serial `axiom-execx -s commands -l`
-# Executing commands from STDIN: `cat commands | axiom-execx --stdin`
-# Execute commands listed from command line `axiom-execx -C "id ; whoami ; hostname"`
-# Running commands against a specifc set of axiom instances or fleet: `axiom-execx -C id -i "jepsen01 jepsen02 jepsen03"`
+# Taking a file of commands and executing them in serial `axiom-orgalorg -s commands -l`
+# Executing commands from STDIN: `cat commands | axiom-orgalorg --stdin`
+# Execute commands listed from command line `axiom-orgalorg -C "id ; whoami ; hostname"`
+# Running commands against a specifc set of axiom instances or fleet: `axiom-orgalorg -C id -i "jepsen01 jepsen02 jepsen03"`
 # 
 # Author : 0xtavian                                                
 # Github : https://github.com/0xtavian                                           
@@ -44,12 +44,12 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 function usage() {
     cat << EOF
-    Usage: Experimental axiom-exec (axiom-execx)
+    Usage: Experimental axiom-exec (axiom-orgalorg)
     Examples:
-     Execute commands from a file, in serial mode : axiom-execx -s commands.txt -l
-     Execute commands from STDIN :  cat commands.txt | axiom-execx --stdin
-     From command line : axiom-execx -C "id ; whoami ; hostname"
-     Against a specifc set of axiom instances or fleet : axiom-execx -C id -i "jepsen01 jepsen02 jepsen03"
+     Execute commands from a file, in serial mode : axiom-orgalorg -s commands.txt -l
+     Execute commands from STDIN :  cat commands.txt | axiom-orgalorg --stdin
+     From command line : axiom-orgalorg -C "id ; whoami ; hostname"
+     Against a specifc set of axiom instances or fleet : axiom-orgalorg -C id -i "jepsen01 jepsen02 jepsen03"
      orgalorg --help for more info 
    
     -C|--Command               Execute command across fleet

--- a/interact/axiom-orgalorg
+++ b/interact/axiom-orgalorg
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 ###################################################################
-# Title	: axiom-execx                                                                                             
-# About	: This is just a simple (read poorly-written) wrapper for two great tools, orgalorg (https://github.com/reconquest/orgalorg), and gee (https://github.com/hahwul/gee).
-# orgalorg is doing most of the heavy lifting. For more details on orgalorg visit the github or run orgalorg -h for the manual.                                                                                 
-# The reason for axiom-execx was to create a more reliable axiom-exec (https://github.com/pry0cc/axiom/blob/master/interact/axiom-exec), that had better variable expansion and execution control.
+# Title	: axiom-orgalorg                                                                                             
+# About	: This is just a simple wrapper for a great tool, orgalorg (https://github.com/reconquest/orgalorg). 
+# For more details on orgalorg visit the github or run orgalorg -h for the manual.                                                                                 
+# The reason for axiom-orgalorg was to create a more reliable axiom-exec (https://github.com/pry0cc/axiom/blob/master/interact/axiom-exec), that had 
+# better variable expansion and execution control.
 # In addition to a more reliable axiom-exec, orgalorg also includes upload and download features, read the orgalorg --help page for more info.
 #
 # Examples: 
@@ -26,21 +27,10 @@ rm -r $HOME/.ssh/sockets > /dev/null 2>&1
 start="$(pwd)"
 BASEOS="$(uname)"
 
-setup_colors() {
-  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
-    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
-  else
-   NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
-  fi
-}
-
 setuptools() {
 # install orgalorg and gee
 if ! type "orgalorg"  > /dev/null; then
 go get github.com/reconquest/orgalorg
-fi
-if ! type "gee" > /dev/null; then
-GO111MODULE=on go get -v github.com/hahwul/gee
 fi
 }
 
@@ -93,8 +83,8 @@ mkdir -p "$tmp/output"
 mkdir -p "$tmp/logs"
 }
 
-generateSSHfile() {
 # take instances in axiom select or from command line and select them
+generateSSHfile() {
 if [[ $selected = 1 ]]; then
   for i in $(cat "$AXIOM_PATH/selected.conf");
   do instance_ip $i | tee -a "$tmp/ips" &>/dev/null;  done
@@ -108,29 +98,42 @@ fi
 }
 
 executeorgalorg() {
+# parse serial flag
+if [[ $serial = 1 ]]; then
+serial='-l'
+else
+serial=
+fi
+
+# check if stdin flag is provided
 if [[ $stdin = 1 ]]; then
+# if the stdin flag is provided check that /dev/stdin has content
 if [ -p /dev/stdin ]; then
   echo "Data was piped to this script!"
-  orgalorg -w -y -o "$tmp/hosts" -i /dev/stdin -C /bin/zsh 
+echo $args  
+orgalorg $serial -w -y -o "$tmp/hosts" -i /dev/stdin -C /bin/zsh 
   exit 1
  else
-  orgalorg -w -y -o "$tmp/hosts" -i $command -C /bin/zsh 
+# if the stdin flag is provided but /dev/stdin does not have content, execute commands from a file instead
+  orgalorg $serial -w -y -o "$tmp/hosts" -i $command -C /bin/zsh 
 fi fi
 
 if [[ $stdin = 0 ]]; then
- orgalorg -w -y -o "$tmp/hosts" -C $command
+# execute command from command line
+ orgalorg $serial -w -y -o "$tmp/hosts" -C $command 
 fi
 }
 
 parse_params() {
   # default values of variables 
+  serial=0
   stdin=0
   selected=1
 
   while :; do
     case "${1-}" in
     -h | --help) usage ;;
-    -l | --serial) ;;            
+    -l | --serial) serial=1 ;;            
     -v | --verbose) set -x ;;
     -s | --stdin) stdin=1
     command="${2-}"
@@ -143,7 +146,6 @@ parse_params() {
       command="${2-}"
       shift
       ;;
-    -?*) die "Unknown option: $1" ;;
     *) break ;;
     esac
     shift
@@ -151,8 +153,7 @@ parse_params() {
 
   args=("$@")
 
-  # check required params and arguments
-
+# check required params and arguments
 if [[ -z "$command" && "$stdin" != 1 ]] ; 
 then 
 echo "You must supply a command in line with -C or from stdin with --stdin" 
@@ -162,14 +163,15 @@ fi
 
 return 0
 }
-
 parse_params "$@"
-setup_colors
 
 # script logic here
+main() {
 setuptools
 tmpfiles
 generateSSHfile
 executeorgalorg
+echo -e "${BGreen}Local logs saved to '${Blue}$AXIOM_PATH/tmp/$uid${BGreen}'!${Color_Off}" 
+}
 
-echo -e "${BGreen}Output saved to '${Blue}$outfile${BGreen}'! Local logs saved to '${Blue}$AXIOM_PATH/tmp/$uid${BGreen}'! ${BGreen}Remote logs saved to '${Blue}/home/op/scan/$uid${BGreen}'!"
+main


### PR DESCRIPTION
    Usage: An experimental axiom-exec aka axiom-orgalorg
    Examples:
     Execute commands from a file, in serial mode : axiom-orgalorg -s commands.txt -l
     Execute commands from STDIN :  cat commands.txt | axiom-orgalorg --stdin
     From command line : axiom-orgalorg -C "id ; whoami ; hostname"
     Against a specifc set of axiom instances or fleet : axiom-orgalorg -C id -i "jepsen01 jepsen02 jepsen03"
     orgalorg --help for more info 
   
    -C|--Command               Execute command across fleet
    -i|--instances             List of axiom instances to execute on, must be wrapped in double quotes (Defaults to ~/.axiom/selected.conf)
    -s|--stdin                 Take commands from STDIN or from a file
    -v|--verbose               Increase verbosity
    -h|--help                  Display this help menu
    -l|--serial                Execute commands in serial 