### PR TITLE
azure username fix

### DIFF
--- a/providers/azure-functions.sh
+++ b/providers/azure-functions.sh
@@ -56,7 +56,7 @@ create_instance() {
 
 	#location="$(az account list-locations | jq -r ".[] | select(.name==\"$region\") | .displayName")"
 	location="$region"
-	az vm create --resource-group axiom --name "$name" --image "$image_id" --location "$location" --size "$size_slug" --tags "$name"=True >/dev/null 2>&1 
+	az vm create --admin-username op>/dev/null 2>&1 e --resource-group axiom --name "$name" --image "$image_id" --location "$location" --size "$size_slug" --tags "$name"=Tru
 
 	az vm open-port --resource-group axiom --name "$name" --port 0-65535 >/dev/null 2>&1 
 	sleep 10

--- a/providers/azure-functions.sh
+++ b/providers/azure-functions.sh
@@ -56,7 +56,7 @@ create_instance() {
 
 	#location="$(az account list-locations | jq -r ".[] | select(.name==\"$region\") | .displayName")"
 	location="$region"
-	az vm create --admin-username op>/dev/null 2>&1 e --resource-group axiom --name "$name" --image "$image_id" --location "$location" --size "$size_slug" --tags "$name"=Tru
+	az vm create --resource-group axiom --name "$name" --image "$image_id" --location "$location" --size "$size_slug" --tags "$name"=True --admin-username op >/dev/null 2>&1 
 
 	az vm open-port --resource-group axiom --name "$name" --port 0-65535 >/dev/null 2>&1 
 	sleep 10


### PR DESCRIPTION
fixes issue where azure users local account name causes az vm create to fail.

"you can specify --admin-username to provide a username for the account to be created on the VM. Without that, the Azure CLI uses the username of your current shell login session. If the username you have logged into the Azure Cloud Shell or local PowerShell session contains those invalid characters, the VM create operation fails."