### PR TITLE
Fix axiom-proxy

### DIFF
--- a/interact/axiom-proxy
+++ b/interact/axiom-proxy
@@ -57,8 +57,8 @@ echo -e "${BGreen}Proxies connected and saved in ./proxychains.conf${Color_Off}"
 
 if [[ "$single_mode" == "true" ]]; then
     echo -e "${Blue}Building haproxy configuration...${Color_Off}"
-    echo -e "FROM haproxy:alpine\nEXPOSE 1337/tcp\nCOPY --chmod=644 haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg" > $tmp/Dockerfile
+    echo -e "FROM haproxy:alpine\nCOPY --chmod=644 haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg" > $tmp/Dockerfile
     sudo docker build -t pry0cc/haproxy $tmp
     echo -e "${BGreen}[*]${Green} Started SOCKS5 Listener on '${Blue}0.0.0.0:1337${BGreen}'... CTRL+C TO EXIT${BGreen}...${Color_Off}"
-    sudo docker run --rm -p 1337:1337 --name axiom-proxy pry0cc/haproxy
+    sudo docker run --rm --network=host --name axiom-proxy pry0cc/haproxy
 fi

--- a/interact/axiom-proxy
+++ b/interact/axiom-proxy
@@ -57,9 +57,8 @@ echo -e "${BGreen}Proxies connected and saved in ./proxychains.conf${Color_Off}"
 
 if [[ "$single_mode" == "true" ]]; then
     echo -e "${Blue}Building haproxy configuration...${Color_Off}"
-    echo -e "FROM haproxy:alpine\nCOPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg" > $tmp/Dockerfile
-    cd "$tmp"
-    sudo docker build -t pry0cc/haproxy
+    echo -e "FROM haproxy:alpine\nEXPOSE 1337/tcp\nCOPY --chmod=644 haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg" > $tmp/Dockerfile
+    sudo docker build -t pry0cc/haproxy $tmp
     echo -e "${BGreen}[*]${Green} Started SOCKS5 Listener on '${Blue}0.0.0.0:1337${BGreen}'... CTRL+C TO EXIT${BGreen}...${Color_Off}"
-    sudo docker run --rm --network=host --name axiom-proxy pry0cc/haproxy
+    sudo docker run --rm -p 1337:1337 --name axiom-proxy pry0cc/haproxy
 fi

--- a/interact/axiom-proxy
+++ b/interact/axiom-proxy
@@ -54,10 +54,12 @@ do
 done
 
 echo -e "${BGreen}Proxies connected and saved in ./proxychains.conf${Color_Off}"
-[[ "$single_mode" == "true" ]] && \
+
+if [[ "$single_mode" == "true" ]]; then
     echo -e "${Blue}Building haproxy configuration...${Color_Off}"
-    echo -e "FROM haproxy:alpine\nCOPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg" > $tmp/Dockerfile && \
-    cd "$tmp" && \
-    sudo docker build -t pry0cc/haproxy .&& \
+    echo -e "FROM haproxy:alpine\nCOPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg" > $tmp/Dockerfile
+    cd "$tmp"
+    sudo docker build -t pry0cc/haproxy
     echo -e "${BGreen}[*]${Green} Started SOCKS5 Listener on '${Blue}0.0.0.0:1337${BGreen}'... CTRL+C TO EXIT${BGreen}...${Color_Off}"
     sudo docker run --rm --network=host --name axiom-proxy pry0cc/haproxy
+fi


### PR DESCRIPTION
`axiom-proxy` was missing && operator in some of the latest commands which was making the script trying to run docker even when user didn't provide "--single" flag. This PR ensures it only runs docker when using that flag.

Also, `docker build` was missing PATH argument, which was causing issues like the following:

![image](https://user-images.githubusercontent.com/7395296/128389655-9211719e-0e2d-4210-9925-467d640065c1.png)

Withe these changes, I was able to successfully run `axiom-proxy --single`:

![image](https://user-images.githubusercontent.com/7395296/128390254-ae25c0a9-9b1d-4ce3-9c99-e7f0c5584fa2.png)

