### PR TITLE
Moved spinup action so $tmp/hosts has the right list.

### DIFF
--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -512,6 +512,15 @@ mkdir -p "$tmp/split"
 mkdir -p "$tmp/output"
 mkdir -p "$tmp/logs"
 
+# Spinup Flag
+#
+if [[ "$spinup" -gt 0 ]]; then
+    echo -e "${Blue}Spinning up fleet with $spinup instances..${Color_Off}"
+    "$AXIOM_PATH/interact/axiom-fleet" -i="$spinup"
+    echo -e "${Green}Waiting 60 seconds before scan...${Color_Off}"
+    sleep 60
+fi
+
 # Not sure why we cat and then cp the selected.conf to different file names
 # Make a copy of the current SSH config and use it for axiom-scan
 #
@@ -548,15 +557,6 @@ fi
 
 if [[ "$module" == "gowitness" ]]; then
     ext=""
-fi
-
-# Spinup Flag
-#
-if [[ "$spinup" -gt 0 ]]; then
-    echo -e "${Blue}Spinning up fleet with $spinup instances..${Color_Off}"
-    "$AXIOM_PATH/interact/axiom-fleet" -i="$spinup"
-    echo -e "${Green}Waiting 60 seconds before scan...${Color_Off}"
-    sleep 60
 fi
 
 # SSH Cache Flag


### PR DESCRIPTION
[Edit: Apologies for the lack of description, I used the web editor.]

I noticed when using `axiom-scan input.txt --spinup 20 ...` that the list of instances would get confused and cause my run to fail. I spent some time looking at axiom-scan and saw that if --fleet is empty (not passed in), then axiom-scan will get the list of instances from `$tmp/hosts`. That file comes from `selected.conf`, but because `axiom-fleet` was being run after the list of instances was already grabbed, the `axiom-select` that `axiom-fleet` calls comes too late.

![image](https://user-images.githubusercontent.com/680830/132175884-415d7e8c-670e-4dc2-b2c7-e94bfc6bf235.png)

This change moves the `axiom-fleet` step to right after the $tmp subdirs are created. I tested that change and this spinup was a success.

![image](https://user-images.githubusercontent.com/680830/132177347-7a13a317-0db3-4bb9-85a2-e99a3f05e1f2.png)
