### PR TITLE
Fix function list_modules() to show all modules

### DIFF
--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -35,8 +35,6 @@ function formatSeconds (){
 function list_modules() {
 	echo -e "${Green}Available Modules:${Color_Off}"
 	(echo "MODULE,COMMAND"; find "$AXIOM_PATH/modules" -name '*.json' -exec echo -n {}\` \; -exec jq -r '.[0].command' {} \; | sort -t/ | sed 's/\/$HOME\/.axiom\/modules\///g' | sed 's/\.json//g' ) | column -t -s\` | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
-  tput init
-
 }
 
 ###########################################################################################################


### PR DESCRIPTION
The command `tput init` at the end of function list_modules() was making it show only part of the available modules, like in the screenshot below. Removing this line make it show all of them.

![image](https://user-images.githubusercontent.com/7395296/137779054-78366bf4-d572-4b00-8cd9-47e61b0895b9.png)
