### PR TITLE
refactoring of axiom-ssh, axiom-init, and axiom-fleet

### DIFF
--- a/interact/axiom-fleet
+++ b/interact/axiom-fleet
@@ -11,7 +11,7 @@ function help() {
     echo -e "  -i=int"
     echo -e "    How many instances you'd like to spin up"
     echo -e "  --regions"
-    echo -e "    Supply comma-separated regions to cycle through e.g. --regions=NYC1,NYC2,NYC3,AMS2,AMS3"
+    echo -e "    Supply comma-separated regions to cycle through e.g. --regions=nyc1,sgp1,lon1,nyc3,ams3,fra1,tor1,blr1,sfo3"
     echo -e "  --help"
     echo -e "    Display this help menu"
 }
@@ -19,11 +19,11 @@ function help() {
 gen_name=""
 provider="$(jq -r ".provider" "$AXIOM_PATH/axiom.json")"
 
-if [ -z $1 ] || [[ $1 =~ "-i" ]] || [[ $1 =~ "-t" ]] 
+if [ -z "$1" ] || [[ $1 =~ "-i" ]] || [[ $1 =~ "-t" ]] 
 then
     gen_name="${names[$RANDOM % ${#names[@]} ]}"
 else
-    if [ ! -z $1 ]
+    if [ ! -z "$1" ]
     then
         gen_name="$1"
     fi
@@ -82,15 +82,15 @@ fi
 
 echo -e "${BWhite}Initializing new fleet '$gen_name' with $amount instances...${Color_Off}"
 total_spend_per_instance_rounded="0"
-slug=$(cat $AXIOM_PATH/axiom.json | jq -r .default_size)  >/dev/null 2>&1
+slug=$(cat "$AXIOM_PATH"/axiom.json | jq -r .default_size)  >/dev/null 2>&1
 
 price_hourly=0
 if [[ "$provider" == "do" ]]; then
 	sizes=$(instance_sizes)
-	instance_data=$(echo $sizes | jq ".[] | select(.slug==\"$slug\")") >/dev/null 2>&1
-	price_hourly=$(echo $instance_data | jq .price_hourly)
+	instance_data=$(echo "$sizes" | jq ".[] | select(.slug==\"$slug\")") >/dev/null 2>&1
+	price_hourly=$(echo "$instance_data" | jq .price_hourly)
 elif [[ "$provider" == "azure" ]]; then
-	price_hourly=$(cat $AXIOM_PATH/pricing/azure.json | jq ".[].costs[] | select(.id==\"$slug\") .firstParty[].meters[].perUnitAmount")
+	price_hourly=$(cat "$AXIOM_PATH"/pricing/azure.json | jq ".[].costs[] | select(.id==\"$slug\") .firstParty[].meters[].perUnitAmount")
 fi
 
 #if [[ "$provider" == "do" ]] | [[ "$provider" == "azure" ]];
@@ -110,16 +110,8 @@ expiry=$(bc <<< "scale=2; $expiry - 8")
 time=320
 
 image_id=""
-image_name=""
-image="$(jq -r '.image' $AXIOM_PATH/axiom.json)"
-region="$(jq -r '.region' $AXIOM_PATH/axiom.json)"
-
-if [[ "$image" != "null" ]]
-then
-	image_name="$image-$region"
-else
-	image_name="axiom-$region"
-fi
+image_name="$(jq -r '.imageid' "$AXIOM_PATH"/axiom.json)"
+region="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
 
 # Basically repeat items, if the fleet is 20 hosts and they only supply 3 regions, loop over them until it reaches 20
 total_regions=$(echo "${region_array[@]}" |  tr ' ' '\n' | wc -l | awk '{ print $1 }')
@@ -164,10 +156,16 @@ do
    args=""
  
 	if [[ "$cycle_regions" != "false" ]]; then
-		args="--uregion=${regions_to_cycle[o]}"	
+		regionargs="${regions_to_cycle[o]}"	
 	fi
-	
-   $AXIOM_PATH/interact/axiom-init $name --quiet --size=$slug --expire=$expiry --image_id="$image_id" $args --no-select &
+
+# make sure region is set
+#
+if [ -z ${regionargs:+x} ]; then
+regionargs="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
+fi
+
+   "$AXIOM_PATH"/interact/axiom-init "$name" --quiet --size "$slug" --image "$image_name" --no-select --region  $regionargs &
    sleep 0.6
    o=$((o+1))
 done

--- a/interact/axiom-fleet
+++ b/interact/axiom-fleet
@@ -1,34 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+###################################################################
+# About	:
+#
+# axiom-fleet lets you spin up fleets of axiom instances in one or multiple regions.
+# You can specify the name of a fleet (fleet prefix) or have axiom choose for you.
+#
+# Examples: 
+#
+# axiom-fleet${Color_Off} # Spin up three instances, let axiom decide on the fleet prefix"
+# axiom-fleet javis -i 10${Color_Off} # Spin up 10 instances with a fleet prefix of javis, this will create 10 instances named javis01 to javis10."
+# axiom-fleet jerry -i 25 --regions nyc1,lon1,ams3,fra1${Color_Off} # Spin up 25 instances using round robbin region distribution"
+###################################################################
+
+###########################################################################################################
+# Header
+#
 AXIOM_PATH="$HOME/.axiom"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 source "$AXIOM_PATH/interact/includes/functions.sh"
+source "$AXIOM_PATH/interact/includes/system-notification.sh"
+begin=$(date +%s)
+start="$(pwd)"
+BASEOS="$(uname)"
+account_path=$(ls -la $AXIOM_PATH/axiom.json | rev | cut -d " " -f 1 | rev)
+accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
+current=$(ls -lh ~/.axiom/axiom.json | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
+case $BASEOS in
+'Darwin')
+    PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
+    ;;
+*) ;;
+esac
 
-function help() {
-    echo -e "${BWhite}Usage of axiom-fleet${Color_Off}"
-    echo -e "Example Usage: ${Blue}axiom-fleet -i=10${Color_Off}. In this case a random name will be selected for the new fleet"
-    echo -e "  ${Blue}axiom-fleet javis -i=10${Color_Off} This will create 10 instances named javis01 to javis10"
-    echo -e "  -i=int"
-    echo -e "    How many instances you'd like to spin up"
-    echo -e "  --regions"
-    echo -e "    Supply comma-separated regions to cycle through e.g. --regions=nyc1,sgp1,lon1,nyc3,ams3,fra1,tor1,blr1,sfo3"
-    echo -e "  --help"
-    echo -e "    Display this help menu"
-}
-
-gen_name=""
-provider="$(jq -r ".provider" "$AXIOM_PATH/axiom.json")"
-
-if [ -z "$1" ] || [[ $1 =~ "-i" ]] || [[ $1 =~ "-t" ]] 
-then
-    gen_name="${names[$RANDOM % ${#names[@]} ]}"
-else
-    if [ ! -z "$1" ]
-    then
-        gen_name="$1"
-    fi
-fi
-
+###########################################################################################################
+# Declare defaut variables
+#
 spend=false
 hours=false
 amount=false
@@ -37,50 +44,123 @@ region=false
 image=false
 cycle_regions=false
 region_array=()
+gen_name=""
+provider="$(jq -r ".provider" "$AXIOM_PATH/axiom.json")"
+image_name="$(jq -r '.imageid' "$AXIOM_PATH"/axiom.json)"
+region="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
+image_id=""
+instances=false
 
+###########################################################################################################
+# Help Menu
+# 
+function usage() {
+        echo -e "${BWhite}Description:"
+        echo -e "  Spin up fleets of axiom instances in one or multiple regions."
+        echo -e "  Specify the name of your fleet (fleet prefix) or have axiom choose for you."
+        echo -e "${BWhite}Examples:${Color_Off}"
+        echo -e "  ${Blue}axiom-fleet${Color_Off} # Spin up three instances, let axiom decide on the fleet prefix"
+        echo -e "  ${Blue}axiom-fleet javis -i 10${Color_Off} # Spin up 10 instances with a fleet prefix of javis, this will create 10 instances named javis01 to javis10."
+        echo -e "  ${Blue}axiom-fleet jerry -i 25 --regions nyc1,lon1,ams3,fra1${Color_Off} # Spin up 25 instances using round robbin region distribution"
+        echo -e "${BWhite}Usage:${Color_Off}"
+        echo -e "  -i/--instances <integer>"
+        echo -e "    The number of instances to spin up"
+        echo -e "  -r/--regions <regions> (optional)"
+        echo -e "    Supply comma-separated regions to cycle through ( default get region from ~/.axiom/axiom.json)"
+        echo -e "  --help (optional)"
+        echo -e "    Display this help menu"
+}
 
-for var in "$@"
+###########################################################################################################
+# Parse command line arguments 
+#
+i=0
+for arg in "$@"
 do
-    if [[ "$var" =~ "-t" ]]
-    then
-        hours="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-        #echo -e "${BWhite}Setting expiry to $hours hours${Color_Off}"
-    fi
-    if [[ "$var" == "-h" ]] || [[ "$var" == "--help" ]];
-    then
-        help
-        exit 0
-    fi
-    if [[ "$var" =~ "-i" ]]
-    then
-        amount="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-        #echo -e "${BWhite}Setting number of instances to $amount...${Color_Off}"
-    fi
-    if [[ "$var" =~ "--regions=" ]]
-    then
-        cycle_regions="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-        echo -e "${BWhite}Cycling through following regions:$cycle_regions...${Color_Off}"
-        IFS=',' read -r -a region_array <<< "$cycle_regions"
-    fi
-    if [[ "$var" =~ "--image=" ]]
-    then
-        image="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-        #echo -e "${BWhite}Setting number of instances to $amount...${Color_Off}"
+    i=$((i+1))
+    if [[  ! " ${pass[@]} " =~ " ${i} " ]]; then
+        set=false
+        if [[ "$i" == 1 ]]; then
+            instance="$1"
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "-i" ]] || [[ "$arg" == "--instances" ]]; then
+            n=$((i+1))
+            instances=true
+            amount=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--regions" ]] || [[ "$arg" == "-r" ]]; then
+            n=$((i+1))
+            cycle_regions=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--image" ]] ; then
+            n=$((i+1))
+            image=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]] || [[ "$arg" == "help" ]]; then
+            usage
+            exit
+            set=true
+            pass+=($i)
+        fi
+        if  [[ "$set" != "true" ]]; then
+            args="$args $arg"
+        fi
     fi
 done
 
-
-if [ "$hours" == "false" ]
-then
-    hours=1
+###########################################################################################################
+# Display Help Menu
+#
+if [[ "$*" == "--help" ]] || [[ "$*" == "-h" ]] ; then
+usage
+exit
 fi
 
-if [ "$amount" == "false" ]
-then
-	amount=3
+###########################################################################################################
+# If -i /--instances isnt used, default to three instances
+#
+if [[ "$amount" == "false" ]]; then
+ amount=3
 fi
 
+###########################################################################################################
+# Generate name TODO clean up
+#
+if [ -z "$1" ] || [[ $1 =~ "-i" ]] || [[ $1 =~ "-t" ]] ; then
+ gen_name="${names[$RANDOM % ${#names[@]} ]}"
+else
+ if [ ! -z "$1" ]; then
+  gen_name="$1"
+ fi
+fi
+
+###########################################################################################################
+# Initialize fleet
+#
+if [[ "$cycle_regions" == "false" ]]; then
+
+# Chance to cancel initialization of fleet
+#
 echo -e "${BWhite}Initializing new fleet '$gen_name' with $amount instances...${Color_Off}"
+echo -e "${BWhite}INITIALIZING IN 5 SECONDS, CTRL+C to quit... ${Color_Off}"
+sleep 5
+
+image_id=$(get_image_id "$image_name")
+total=$(query_instances "$gen_name*" | tr " " "\n" | sed 's/[^0-9]*//g'| sort -nr | head -n1)
+start=$((total))
+amount=$(($amount+$start))
+start=$((start+1))
 total_spend_per_instance_rounded="0"
 slug=$(cat "$AXIOM_PATH"/axiom.json | jq -r .default_size)  >/dev/null 2>&1
 
@@ -93,81 +173,20 @@ elif [[ "$provider" == "azure" ]]; then
 	price_hourly=$(cat "$AXIOM_PATH"/pricing/azure.json | jq ".[].costs[] | select(.id==\"$slug\") .firstParty[].meters[].perUnitAmount")
 fi
 
-#if [[ "$provider" == "do" ]] | [[ "$provider" == "azure" ]];
-#then
-#	
-#	total=$(bc <<< "scale=2; $price_hourly * $hours * $amount")
-#	total_rounded=$(echo "scale=3; price=$total; scale=2; price/1 " | bc | sed 's/^\./0./')
-#	total_spend_per_instance=$(bc <<< "scale=2; $price_hourly * $hours")
-#	total_spend_per_instance_rounded=$(echo "scale=3; price=$total_spend_per_instance; scale=4; price/1 " | bc | sed 's/^\./0./')
-#	echo -e "${Green}Total estimated cost: \$$total_rounded${Color_Off}"
-#fi
-
-echo -e "${BWhite}INITIALIZING IN 3 SECONDS, CTRL+C to quit... ${Color_Off}"
-
 expiry=$(bc <<< "scale=2; $hours * 60")
 expiry=$(bc <<< "scale=2; $expiry - 8")
 time=320
-
-image_id=""
-image_name="$(jq -r '.imageid' "$AXIOM_PATH"/axiom.json)"
-region="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
-
-# Basically repeat items, if the fleet is 20 hosts and they only supply 3 regions, loop over them until it reaches 20
-total_regions=$(echo "${region_array[@]}" |  tr ' ' '\n' | wc -l | awk '{ print $1 }')
-regions_to_cycle=()
-
-if [[ "$cycle_regions" != "false" ]]; then
-	
-	k=0
-	while [[ "$(echo ${regions_to_cycle[@]} | tr ' ' '\n' | wc -l | awk '{ print $1}')" -lt "$amount" ]]
-	do
-		regions_to_cycle+=("${region_array[k]}")
-		if [[ "$k" -lt "$total_regions" ]]; then
-			k=$((k+1))
-		else
-			k=0
-		fi
-	done
-fi
-
-# Remove  null items from array
-for i in "${!regions_to_cycle[@]}"; do
-  [ -n "${regions_to_cycle[$i]}" ] || unset "regions_to_cycle[$i]"
-done
-
-image_id=$(get_image_id "$image_name")
-total=$(query_instances "$gen_name*" | tr " " "\n" | sed 's/[^0-9]*//g'| sort -nr | head -n1)
-
-start=$((total))
-#[[ "$total" -lt 1 ]] && start=$((start+1))
-
-amount=$(($amount+$start))
-
-start=$((start+1))
-
 echo -n -e "${BWhite}Instances: ${Color_Off}[ ${Blue}"
 o=0
 for i in $(seq -f "%02g" $start $amount)
 do
-   time=$((time+6))
-   name="$gen_name$i"
-   echo -n -e "$name "
-   args=""
- 
-	if [[ "$cycle_regions" != "false" ]]; then
-		regionargs="${regions_to_cycle[o]}"	
-	fi
-
-# make sure region is set
-#
-if [ -z ${regionargs:+x} ]; then
-regionargs="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
-fi
-
-   "$AXIOM_PATH"/interact/axiom-init "$name" --quiet --size "$slug" --image "$image_name" --no-select --region  $regionargs &
-   sleep 0.6
-   o=$((o+1))
+ time=$((time+6))
+ name="$gen_name$i"
+ echo -n -e "$name "
+ args=""
+"$AXIOM_PATH"/interact/axiom-init "$name" --quiet --size "$slug" --image "$image_name" --no-select --region  $region &
+sleep 0.6
+o=$((o+1))
 done
 echo -n -e "${Color_Off} ]\n"
 
@@ -176,7 +195,90 @@ while [ $time -gt 0 ]; do
     sleep 1
     : $((time--))
 done
+fi
 
-$AXIOM_PATH/interact/axiom-select "$gen_name*"
+###########################################################################################################
+# Round Robin distribution logic here ( i.e. regions_to_cycle)
+#
+if [[ "$cycle_regions" != "false" ]]; then
+
+###########################################################################################################
+# Chance to cancel initialization of fleet
+#
+echo -e "${BWhite}Initializing new fleet '$gen_name' with $amount instances...${Color_Off}"
+echo -e "${BWhite}Cycling through following regions:$cycle_regions...${Color_Off}"
+echo -e "${BWhite}INITIALIZING IN 5 SECONDS, CTRL+C to quit... ${Color_Off}"
+sleep 5
+image_id=$(get_image_id "$image_name")
+total=$(query_instances "$gen_name*" | tr " " "\n" | sed 's/[^0-9]*//g'| sort -nr | head -n1)
+start=$((total))
+amount=$(($amount+$start))
+start=$((start+1))
+total_spend_per_instance_rounded="0"
+slug=$(cat "$AXIOM_PATH"/axiom.json | jq -r .default_size)  >/dev/null 2>&1
+
+price_hourly=0
+if [[ "$provider" == "do" ]]; then
+        sizes=$(instance_sizes)
+        instance_data=$(echo "$sizes" | jq ".[] | select(.slug==\"$slug\")") >/dev/null 2>&1
+        price_hourly=$(echo "$instance_data" | jq .price_hourly)
+elif [[ "$provider" == "azure" ]]; then
+        price_hourly=$(cat "$AXIOM_PATH"/pricing/azure.json | jq ".[].costs[] | select(.id==\"$slug\") .firstParty[].meters[].perUnitAmount")
+fi
+
+expiry=$(bc <<< "scale=2; $hours * 60")
+expiry=$(bc <<< "scale=2; $expiry - 8")
+time=320
+ IFS=',' read -r -a region_array <<< "$cycle_regions"
+
+# Basically repeat items, if the fleet is 20 hosts and they only supply 3 regions, loop over them until it reaches 20
+total_regions=$(echo "${region_array[@]}" |  tr ' ' '\n' | wc -l | awk '{ print $1 }')
+regions_to_cycle=()
+ k=0
+ while [[ "$(echo ${regions_to_cycle[@]} | tr ' ' '\n' | wc -l | awk '{ print $1}')" -lt "$amount" ]]
+ do
+  regions_to_cycle+=("${region_array[k]}")
+  if [[ "$k" -lt "$total_regions" ]]; then
+   k=$((k+1))
+  else
+   k=0
+  fi
+done
+
+# Remove  null items from array
+for i in "${!regions_to_cycle[@]}"; do
+  [ -n "${regions_to_cycle[$i]}" ] || unset "regions_to_cycle[$i]"
+done
+echo -n -e "${BWhite}Instances: ${Color_Off}[ ${Blue}"
+o=0
+for i in $(seq -f "%02g" $start $amount)
+do
+time=$((time+6))
+name="$gen_name$i"
+echo -n -e "$name "
+args=""
+ 
+regionargs="${regions_to_cycle[o]}"
+
+# make sure region is set
+#
+if [ -z ${regionargs:+x} ]; then
+regionargs="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
+fi
+
+"$AXIOM_PATH"/interact/axiom-init "$name" --quiet --size "$slug" --image "$image_name" --no-select --region  $regionargs &
+sleep 0.6
+o=$((o+1))
+done
+echo -n -e "${Color_Off} ]\n"
+fi
+
+while [ $time -gt 0 ]; do
+ echo -ne ">> T-Minus $time to fleet $gen_name initialization...\033[0K\r"
+ sleep 1
+ : $((time--))
+done
+
+"$AXIOM_PATH"/interact/axiom-select "$gen_name*"
 
 echo -e "${BGreen}Fleet started succesfully!\nTo delete your fleet, just run '${Blue}axiom-rm \"$gen_name*\" -f${BGreen}'${Color_Off}"

--- a/interact/axiom-init
+++ b/interact/axiom-init
@@ -92,6 +92,8 @@ waitabit() {
 #                                                                                                                                                                                                           
 # axiom-init testy01 --region nyc3 --image axiom-barebones-1635920849 --size s-1vcpu-2gb --deploy desktop --shell
 function usage() {
+        echo -e "${BWhite}Description:"
+        echo -e "  Initialize one axiom instance with differnet options, such as image, region, size and axiom deployment profile"
         echo -e "${BWhite}Examples:${Color_Off}"
         echo -e "  ${Blue}axiom-init${Color_Off} # provision instance with random name"
         echo -e "  ${Blue}axiom-init --deploy desktop ${Color_Off}# provision instance with random name, then deploy axiom profile 'desktop'"

--- a/interact/axiom-init
+++ b/interact/axiom-init
@@ -1,82 +1,48 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+###########################################################################################################
+# Title	: axiom-init
+# About: Initialize axiom instances with differnet options, such as image, region, size and axiom deployment profile
+#
+# Examples: 
+#
+# axiom-init # provision instance with random name
+# axiom-init --deploy desktop # provision instance with random name, then deploy axiom profile 'desktop'
+# axiom-init testy01 # provision instance named testy01
+#
+# axiom-init testy01 --region nyc3 --image axiom-barebones-1635920849 --size s-1vcpu-2gb --deploy desktop --shell
+#
+###########################################################################################################
+
+###########################################################################################################
+# Header
+#
 AXIOM_PATH="$HOME/.axiom"
 DOCTL_CONFIG_PATH="$HOME/.config/doctl/config.yaml"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 source "$AXIOM_PATH/interact/includes/functions.sh"
 source "$AXIOM_PATH/interact/includes/system-notification.sh"
-
+starttime=$(date +"%F-TIME-%T")
+start="$(pwd)"
 BASEOS="$(uname)"
 provider="$(jq -r ".provider" "$AXIOM_PATH/axiom.json")"
+account_path=$(ls -la "$AXIOM_PATH"/axiom.json | rev | cut -d " " -f 1 | rev)
+accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
+current=$(ls -lh ~/.axiom/axiom.json | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
+case $BASEOS in
+'Darwin')
+    PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
+    ;;
+*) ;;
+esac
 
-function help() {
-	echo -e "${BWhite}Usage of axiom-init${Color_Off}"
-	echo -e "Example Usage: ${Blue}axiom-init bigstok${Color_Off}"
-	echo -e "  <name> string (optional)"
-	echo -e "    Name of the instance, supplied as a positional first argument"
-	echo -e "  --deploy=<profile>"
-	echo -e "    Deploy a profile after initialization (e.g desktop, openvpn, bbrf, wireguard)"
-	echo -e "  --restore=<backup>"
-	echo -e "    Initialize with a previous backup"
-  echo -e "  --shell (optional)"
-  echo -e "    Connect to instance after initialization"
-  echo -e "  --uregion=<region>"                                                          
-  echo -e "    User specified region to use (default is to use region in ~/.axiom/account/account.json)"
-  echo -e "  --size=<vm size>"                                                           
-  echo -e "    VM size to use  (default is to use size in ~/.axiom/account/account.json)"
-  echo -e "  --image-id=<image id>"
-  echo -e "    Manually set the image id (default is to use image id in ~/.axiom/account/account.json)"
-  echo -e "  --image=<image name>"
-  echo -e "    Select image-id from image-name (default is to use image-name in ~/.axiom/account/account.json)"
-  echo -e "  --domain=<example.com>"
-  echo -e "    Manually specify the domain to use (default is specified by cloud provider)"
-  echo -e "  --no-select (optional)"
-  echo -e "    Dont select instance after initialization (default is to select instance)"
-	echo -e "  --help"
-	echo -e "    Display this help menu"
-}
-
-# function called by trap
-other_commands() {
-    tput setaf 1
-    printf "\rExiting..."
-    echo "Cleaning up created resources..."
-    kill -9  "$PID"
-    $AXIOM_PATH/interact/axiom-rm $gen_name -f
-	echo "Thank you for using axiom :) - @pry0cc"
-	exit
-}
-
-trap 'other_commands' SIGINT
-
-if [[ "$provider" == "do" ]]; then
-# Per doctl readme the config path differs on OSX: https://github.com/digitalocean/doctl#configuring-default-values
-if [ $BASEOS == "Darwin" ]; then DOCTL_CONFIG_PATH=~/"Library/Application Support/doctl/config.yaml"; fi
-
-if ! command -v doctl &> /dev/null
-then
-    echo -e "${BRed}Error: doctl could not be found. Please install it from the binary${No_Color}"
-    exit
-else
-	token_length=$(cat "$DOCTL_CONFIG_PATH"  | grep access-token | wc -c | awk '{ print $1 }')
-	if [[ "$token_length" -lt 32 ]];
-	then
-		echo -e "${Red}Warning: it looks like your doctl might not be configured with a token!${Color_Off}"
-	fi
-fi
-fi
-
-if ! command -v jq &> /dev/null
-then
-    echo -e "${BRed}Error: jq could not be found. Please install it.${No_Color}"
-    exit
-fi
-
+###########################################################################################################
+# Declare defaut variables
+#
 gen_name="${names[$RANDOM % ${#names[@]}]}$((10 + RANDOM % 20))"
-region="$(jq -r '.region' $AXIOM_PATH/axiom.json)"
-size="$(jq -r '.default_size' $AXIOM_PATH/axiom.json)"
-image="$(jq -r '.image' $AXIOM_PATH/axiom.json)"
-
+region="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
+size="$(jq -r '.default_size' "$AXIOM_PATH"/axiom.json)"
+image="$(jq -r '.imageid' "$AXIOM_PATH"/axiom.json)"
 box_name=""
 connect_shell=false
 restore=false
@@ -85,190 +51,274 @@ expire=false
 default_expiry=525600000
 quiet=false
 domain=false
-manual_image_id=false
-user_region=""
 no_select=false
 
-if [ -z "$1" ] || [[ $1 =~ "image" ]] || [[ $1 =~ "shell" ]] || [[ $1 =~ "restore" ]] || [[ $1 =~ "deploy" ]] || [[ $1 =~ "size" ]] || [[ $1 =~ "expire" ]] || [[ $1 =~ "quiet" ]] | [[ $1 =~ "domain" ]]; then
-	name="$gen_name"
-else
-	name="$1"
-fi
+###########################################################################################################
+# spinner functions
+# TODO https://github.com/pry0cc/axiom/issues/175
+#
+show_spinner() {
+        local -r pid="${1}"
+        # This delay is very carefully selected, as it makes makes the spinup feelfaster!!!
+        local -r delay='0.48'
+        # I picked 230 because it's slightly too high, you'll feel happy abouta fast spin time ;_
+        i=420
+        while ps a | awk '{print $1}' | grep -q "${pid}"; do
+                echo -ne "${BWhite}>> T-Minus $i to full initialization...${Color_Off}\r"
+                : $((i--))
+                sleep "$delay"
+        done
+        printf "    \b\b\b\b"
+}
+waitabit() {
+        local -r pid="${1}"
+        # This delay is very carefully selected, as it makes makes the spinup feelfaster!!!
+        local -r delay='0.38'
+        # I picked 230 because it's slightly too high, you'll feel happy abouta fast spin time ;_
+        i=420
+        while ps a | awk '{print $1}' | grep -q "${pid}"; do
+                : $((i--))
+                sleep "$delay"
+        done
+        printf "    \b\b\b\b"
+}
 
-for var in "$@"; do
-	if [ "$var" == "--shell" ]; then
-		connect_shell=true
-	fi
-	if [ "$var" == "--quiet" ]; then
-		quiet=true
-	fi
-	if [ "$var" == "--no-select" ]; then
-		no_select=true
-	fi
-	if [[ "$var" == "-h" ]] || [[ "$var" == "--help" ]];
-    then
-        help
-        exit 0
+###########################################################################################################
+# Help Menu:
+# 
+# axiom-init # provision instance with random name                                                                                                                                                          
+# axiom-init --deploy desktop # provision instance with random name, then deploy axiom profile 'desktop'                                                                                                    
+# axiom-init testy01 # provision instance named testy01                                                                                                                                                     
+#                                                                                                                                                                                                           
+# axiom-init testy01 --region nyc3 --image axiom-barebones-1635920849 --size s-1vcpu-2gb --deploy desktop --shell
+function usage() {
+        echo -e "${BWhite}Examples:${Color_Off}"
+        echo -e "  ${Blue}axiom-init${Color_Off} # provision instance with random name"
+        echo -e "  ${Blue}axiom-init --deploy desktop ${Color_Off}# provision instance with random name, then deploy axiom profile 'desktop'"
+        echo -e "  ${Blue}axiom-init testy01${Color_Off} # provision instance named testy01"
+        echo -e "  ${Blue}axiom-init stok01 --region nyc3 --image axiom-barebones-1635920849 --size s-1vcpu-2gb --deploy desktop --shell${Color_Off}"
+        echo -e "${BWhite}Usage:${Color_Off}"
+        echo -e "  <name> string (optional)"
+        echo -e "    Name of the instance, supplied as a positional first argument"
+        echo -e "  --image <image name>"
+        echo -e "    Manually set the image to use (default is imageid in ~/.axiom/axiom.json)"
+        echo -e "  --region <region>"
+        echo -e "    User specified region to use (default is region in ~/.axiom/axiom.json)"
+        echo -e "  --deploy <profile>"
+        echo -e "    Deploy a profile after initialization (e.g desktop, openvpn, bbrf, wireguard)"
+        echo -e "  --shell (optional)"
+        echo -e "    Connect to instance after initialization"
+        echo -e "  --size <vm size>"
+        echo -e "    VM size to use  (default is size in ~/.axiom/account/account.json)"
+        echo -e "  --no-select (optional)"
+        echo -e "    Dont select instance after initialization (default is to select instance)"
+        echo -e "  --domain <example.com>"
+        echo -e "    Manually specify the domain to use (default is specified by cloud provider)"
+        echo -e "  --restore <backup>"
+        echo -e "    Initialize with a previous backup"
+        echo -e "  --help"
+        echo -e "    Display this help menu"
+}
+
+###########################################################################################################
+# Parse command line arguments 
+#
+i=0
+for arg in "$@"
+do
+    i=$((i+1))
+    if [[  ! " ${pass[@]} " =~ " ${i} " ]]; then
+        set=false
+        if [[ "$i" == 1 ]]; then
+            instance="$1"
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--shell" ]]; then
+            shell=true
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--quiet" ]]; then
+            quiet=true          
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--no-select" ]]; then
+            no_select=true
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--restore" ]]; then
+            n=$((i+1))
+            restore=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--region" ]]; then
+            n=$((i+1))
+            region=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--deploy" ]]; then
+            n=$((i+1))
+            deploy=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--domain" ]]; then
+            n=$((i+1))
+            domain=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--size" ]] ; then
+            n=$((i+1))
+            size=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--image" ]]; then
+            n=$((i+1))
+            image=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]] || [[ "$arg" == "help" ]]; then
+            usage
+            exit
+            set=true
+            pass+=($i)
+        fi
+        if  [[ "$set" != "true" ]]; then
+            args="$args $arg"
+        fi
     fi
-	if [[ $var =~ "--restore" ]]; then
-		restore="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		echo -e "${BWhite}Using restore backup '$restore'${Color_Off}"
-	fi
-	if [[ $var =~ "--uregion" ]]; then
-		user_region="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		#echo -e "${BWhite}Using user region '$user_region'${Color_Off}"
-	fi
-	if [[ "$var" =~ "--deploy" ]]; then
-		deploy="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		echo -e "${BWhite}Deploying '$deploy' after init${Color_Off}"
-	fi
-	if [[ "$var" =~ "--domain=" ]]; then
-		domain="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		if [ "$quiet" != "true" ]; then
-			echo -e "${BWhite}Manually setting domain to '$domain'${Color_Off}"
-		fi
-	fi
-	if [[ "$var" =~ "--size" ]]; then
-		size="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		if [ "$quiet" != "true" ]; then
-			echo -e "${BWhite}Manually setting size to '$size'${Color_Off}"
-		fi
-	fi
-	if [[ "$var" =~ "--image=" ]]; then
-		image="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		if [ "$quiet" != "true" ]; then
-			echo -e "${BWhite}Setting image to '$image'${Color_Off}"
-		fi
-	fi
-	if [[ "$var" =~ "--image-id=" ]]; then
-		manual_image_id="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		if [ "$quiet" != "true" ]; then
-			echo -e "${BWhite}Setting image id to '$image'${Color_Off}"
-		fi
-	fi
-
-	if [[ "$var" =~ "--expire" ]]; then
-		expire="$(echo "$var" | sed 's/=/ /g' | awk '{ print $2 }')"
-		default_expiry=${expire%\.*}
-		if [ "$quiet" != "true" ]; then
-			echo -e "${BWhite}Setting expiry to $expire minutes...(This is non-functional)${Color_Off}"
-		fi
-	fi
 done
 
-
-if [[ "$quiet" != "true" ]]; then
-	"$NOTIFY_CMD" "Axiom Info" "Initializing '$name'..."
-	echo -e "${BWhite}Initializing '$name'"
+###########################################################################################################
+# Display Help Menu
+#
+if [[ "$*" == "--help" ]] || [[ "$*" == "-h" ]] ||  [[ "$*" == "help" ]]; then
+usage
+exit
 fi
 
-
-image_name=""
-if [[ "$image" != "null" ]]
-then
-	image_name="$image-$region"
+###########################################################################################################
+# Set instance name
+# TODO: clean this up
+# TODO: If gen_name is already taken, rerun gen_name
+if [ -z "$1" ] || [[ $1 =~ "shell" ]] || [[ $1 =~ "restore" ]] || [[ $1 =~ "region" ]] || [[ $1 =~ "uregion=" ]] || [[ $1 =~ "deploy" ]] || [[ $1 =~ "size" ]] ||  [[ $1 =~ "quiet" ]] || [[ $1 =~ "domain" ]] || [[ $1 =~ "image" ]] || [[ $1 =~ "no-select" ]]; then
+        name="$gen_name"
 else
-  image_name="$(jq -r ".imageid" "$AXIOM_PATH/axiom.json")"
+        name="$1"
 fi
 
-image_id=""
-if  [[ "$manual_image_id" != "false" ]]
-then
-	image_id="$manual_image_id"
-else
-	image_id="$(get_image_id "$image_name")"
-fi
-
-show_spinner() {
-	local -r pid="${1}"
-	# This delay is very carefully selected, as it makes makes the spinup feelfaster!!!
-	local -r delay='0.48'
-	# I picked 230 because it's slightly too high, you'll feel happy abouta fast spin time ;_
-	i=420
-	while ps a | awk '{print $1}' | grep -q "${pid}"; do
-		echo -ne "${BWhite}>> T-Minus $i to full initialization...${Color_Off}\r"
-		: $((i--))
-		sleep "$delay"
-	done
-	printf "    \b\b\b\b"
-}
-
-waitabit() {
-	local -r pid="${1}"
-	# This delay is very carefully selected, as it makes makes the spinup feelfaster!!!
-	local -r delay='0.38'
-	# I picked 230 because it's slightly too high, you'll feel happy abouta fast spin time ;_
-	i=420
-	while ps a | awk '{print $1}' | grep -q "${pid}"; do
-		: $((i--))
-		sleep "$delay"
-	done
-	printf "    \b\b\b\b"
-}
-
-mkdir -p "$AXIOM_PATH/tmp/"
-
+###########################################################################################################
+# Get image_id from $image ( default is from axiom.json )  
+#
+image_id="$(get_image_id "$image")"
 if [ -z "$image_id" ]; then
-	echo -e "${BRed}An image has not been found in this region. Do you need to run 'axiom-build'?${Color_Off}"
-	exit 1
+        echo -e "${BRed}An image has not been found in this region. Do you need to run 'axiom-build'?${Color_Off}"
+        exit 1
 fi
 
+###########################################################################################################
+# Function called by trap
+#
+other_commands() {
+    tput setaf 1
+    printf "\rExiting..."
+    echo "Cleaning up created resources..."
+    kill -9  "$PID"
+    "$AXIOM_PATH"/interact/axiom-rm "$gen_name" -f
+        echo "Thank you for using axiom :) - @pry0cc"
+        exit
+}
 
-if [[ "$user_region" == "" ]]; then
-	user_region="$region"
-fi
+trap 'other_commands' SIGINT
 
-create_instance "$name" "$image_id" "$size" "$user_region" &
+
+###########################################################################################################
+# quiet flag
+#
+if [ $quiet == "true" ]
+then
+create_instance "$name" "$image_id" "$size" "$region" &
 PID="$!"
-if [ "$quiet" != "true" ]; then
-	show_spinner "$PID"
+waitabit "$PID"
+sleep 20
 else
-	waitabit "$PID"
+
+###########################################################################################################
+# Create instance
+#
+echo -e "${BWhite}Initializing '$name' at '$region' with image '$image'"
+mkdir -p "$AXIOM_PATH/tmp/"
+create_instance "$name" "$image_id" "$size" "$region" &
+PID="$!"
+"$NOTIFY_CMD" "Axiom Info" "Initializing '$name'..."
+
+# echo deployment profile when needed
+if [ "$deploy" != false ]; then
+echo -e "${BWhite}Deploying '$deploy' after init${Color_Off}"
 fi
 
-if [ "$quiet" != "true" ]; then
-	secs=$((20))
-	while [ $secs -gt 0 ]; do
-		echo -ne "${BWhite}>> T-Minus $secs to full initialization...${Color_Off}\r"
-		sleep 1
-		: $((secs--))
-	done
-else
-	sleep 20
-fi
+show_spinner "$PID"
+secs=$((20))
+while [ $secs -gt 0 ]; do
+ echo -ne "${BWhite}>> T-Minus $secs to full initialization...${Color_Off}\r"
+ sleep 1
+ : $((secs--))
+done
 
 ip="$(instance_ip "$name")"
 ssh-keygen -R "[$ip]:2266" >>  /dev/null 2>&1
-
-
-if [[ "$no_select" != "true" ]]; then
-	echo "$name" > $AXIOM_PATH/selected.conf
-fi
-
-if [[ "$no_select" != "true" ]]; then
-	"$NOTIFY_CMD" "Axiom Info" "$name successfully initialized at $ip!"
-fi
+axiom-exec "touch /tmp/.connected && echo $(echo "$name" | tr -d "'") | tee /home/op/.name" "$name" -q >> /dev/null 2>&1
 echo -e "${BWhite}Initialized instance '${BGreen}$name${Color_Off}${BWhite}' at '${BGreen}$ip${BWhite}'!"
-
-if [ "$quiet" != "true" ]; then
-	echo -e "${BWhite}To connect, run '${BGreen}axiom-ssh $name${Color_Off}'${BWhite} or '${BGreen}axiom-connect'${Color_Off}"
+echo -e "${BWhite}To connect, run '${BGreen}axiom-ssh $name${Color_Off}'${BWhite} or '${BGreen}axiom-connect'${Color_Off}"
+"$NOTIFY_CMD" "Axiom Info" "$name successfully initialized at $ip!"
 fi
 
-axiom-exec "touch /tmp/.connected && echo $(echo $name | tr -d "'") | tee /home/op/.name" "$name" -q >> /dev/null 2>&1
+###########################################################################################################
+# no_select flag
+#
+if [[ "$no_select" != "true" ]]; then
+echo "$name" > "$AXIOM_PATH"/selected.conf
+fi
 
+###########################################################################################################
+# restore flag
+#
 if [ "$restore" != false ]; then
 	#echo -e "${BWhite}Waiting 65 seconds before restore...${Color_Off}"
-	$AXIOM_PATH/interact/axiom-restore "$restore" "$name"
+	"$AXIOM_PATH"/interact/axiom-restore "$restore" "$name"
 fi
 
+###########################################################################################################
+# deploy flag
+#
 if [ "$deploy" != false ]; then
 	#echo -e "${BWhite}Waiting 65 seconds before deploy... ${Color_Off}"
-	$AXIOM_PATH/interact/axiom-deploy "$deploy" "$name"
+	"$AXIOM_PATH"/interact/axiom-deploy "$deploy" "$name"
 fi
 
-#if [ "$domain" != false ]; then
-##	echo -e "${BWhite}Adding DNS record $name.$domain to -> $ip"
-#	$AXIOM_PATH/interact/axiom-dns add $name $domain $ip
-#fi
+###########################################################################################################
+# add axiom-init stats to stats.log
+#
+echo "{\"init\":\"$name\",\"ip\":\"$ip\",\"time\":\"$starttime\",\"region\":\"$region\",\"size\":\"$size\",\"image\":\"$image\",\"deploy\":\"$deploy\"}"  >> $AXIOM_PATH/stats.log
 
-$AXIOM_PATH/interact/header.sh
+###########################################################################################################
+# connect shell flag
+#
+if [[ $shell == "true" ]];
+then
+axiom-ssh $name --cache
+fi

--- a/interact/axiom-init
+++ b/interact/axiom-init
@@ -255,6 +255,9 @@ create_instance "$name" "$image_id" "$size" "$region" &
 PID="$!"
 waitabit "$PID"
 sleep 20
+ip="$(instance_ip "$name")"
+ssh-keygen -R "[$ip]:2266" >>  /dev/null 2>&1
+echo -e "${BWhite}Initialized instance '${BGreen}$name${Color_Off}${BWhite}' at '${BGreen}$ip${BWhite}'!"
 else
 
 ###########################################################################################################

--- a/interact/axiom-power
+++ b/interact/axiom-power
@@ -37,6 +37,7 @@ on=false
 help=true
 off=false
 reboot=false
+force=false
 
 # Parse command line arguments 
 #
@@ -81,6 +82,11 @@ do
             set=true
             pass+=($i)
         fi
+        if [[ "$arg" == "--force" ]] || [[ "$arg" == "-f" ]]; then
+            force=true
+            set=true
+            pass+=($i)
+        fi
         if [[ "$arg" == "--debug" ]]; then
             debug="true"
             set=true
@@ -112,7 +118,7 @@ if [[ "$off" == "true" ]]; then
     for i in $(echo $instances); 
         do 
             echo -e "${Yellow}Powering off instance: $i${Color_Off}"
-            poweroff $i; 
+            poweroff $i $force; 
         done
 fi
 
@@ -129,20 +135,23 @@ if [[ "$on" == "true" ]]; then
     for i in $(echo $instances); 
         do 
             echo -e "${Yellow}Powering on instance: $i${Color_Off}"
-            poweron $i; 
+            poweron $i $force; 
         done
 fi
 
 # Reboot Snapshots
 #
 if [[ "$reboot" == "true" ]]; then
-    if [[ ${#instances} == 0 ]];then
+    instances=$(query_instances "$@"|sort -u|tr ' ' '\n')
+  
+  if [[ ${#instances} == 0 ]];then
         usage
         exit
     fi
+
     for i in $(echo $instances); 
         do 
             echo -e "${Yellow}Rebooting instance: $i${Color_Off}"
-            reboot $i; 
+            reboot $i $force; 
         done
 fi

--- a/interact/axiom-ssh
+++ b/interact/axiom-ssh
@@ -53,9 +53,20 @@ toggle=false
 # Help Menu:
 # 
 function usage() {
-        echo -e "${BWhite}Usage of axiom-ssh${Color_Off}"
-        echo -e "Example Usage: ${Blue}axiom-ssh --just-generate private && axiom-ssh <instance>${Color_Off}"
-        echo -e "${Blue}axiom-ssh jerry01 --tmux newsessiontmux --cache${Color_Off}"
+        echo -e "${BWhite}Description:"
+        echo -e "  axiom-ssh dynamically generates axiom's SSH config based on your cloud inventory." 
+        echo -e "  axiom-ssh allows you to connect to your axiom instances over their public or private network interface." 
+        echo -e "  axiom-ssh can drop you right into a freshly created tmux session on the remote instance, and can be used to"
+        echo -e "  attach to a preexisting tmux session." 
+        echo -e "  All additional SSH args are passed to SSH.${Color_Off}"
+        echo -e "${BWhite}Examples:${Color_Off}"
+        echo -e "  ${Blue}axiom-ssh testy01${Color_Off} # SSH into instance testy01"
+        echo -e "  ${Blue}axiom-ssh testy01 --tmux mysession1${Color_Off} # SSH into instance testy01 and spawn or attach to session named mysession1"
+        echo -e "  ${Blue}axiom-ssh --just-generate${Color_Off} # Always populate axiom's ssh config (located in ~/.axiom/.sshconfig) with public Ip details"
+        echo -e "  ${Blue}axiom-ssh --just-generate private${Color_Off} # Always populate axiom's ssh config (located in ~/.axiom/.sshconfig) with private Ip details"
+        echo -e "  ${Blue}axiom-ssh --just-generate cache${Color_Off} # Never regenerate axiom's ssh config" 
+        echo -e "  ${Blue}axiom-ssh testy01 -L 8080:127.0.0.1:8080 -D 4040 ${Color_Off} # Port-forward 8080 to local port 8080 and dynamically port foward port 4040 to testy01"
+        echo -e "${BWhite}Usage:${Color_Off}"
         echo -e "  <instance name> required string"
         echo -e "    Instance name supplied as a positional first argument"
         echo -e "  --mosh/-m <instance name> (optional)"

--- a/providers/do-functions.sh
+++ b/providers/do-functions.sh
@@ -66,7 +66,7 @@ instance_pretty() {
 
 	i=0
 	for f in $(echo $data | jq -r '.[].size.price_monthly'); do new=$(expr $i + $f); i=$new; done
-	(echo "Instance,Primary Ip,Backend Ip,Region,Memory,Status,\$/M" && echo $data | jq  -r '.[] | [.name, .networks.v4[0].ip_address, .networks.v4[1].ip_address, .region.slug, .size_slug, .status, .size.price_monthly] | @csv' && echo "_,_,_,_,_,Total,\$$i") | sed 's/"//g' | column -t -s, | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
+	(echo "Instance,Primary Ip,Backend Ip,Region,Size,Status,\$/M" && echo $data | jq  -r '.[] | [.name, .networks.v4[0].ip_address, .networks.v4[1].ip_address, .region.slug, .size_slug, .status, .size.price_monthly] | @csv' && echo "_,_,_,_,_,Total,\$$i") | sed 's/"//g' | column -t -s, | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
 }
 
 # identifies the selected instance/s

--- a/providers/ibm-functions.sh
+++ b/providers/ibm-functions.sh
@@ -12,17 +12,35 @@ ibmcloud sl vs list --column datacenter --column domain --column hostname --colu
 
 poweron() {
 instance_name="$1"
+force="$2"
+if [ "$force" == "true" ]
+then
+ibmcloud sl vs power-on $(instance_id $instance_name) --force
+else
 ibmcloud sl vs power-on $(instance_id $instance_name)
+fi
 }
 
 poweroff() {
 instance_name="$1"
-ibmcloud sl vs power-off $(instance_id $instance_name)
+force="$2"
+if [ "$force" == "true" ]
+then
+ibmcloud sl vs power-off $(instance_id $instance_name) --force
+else
+ibmcloud sl vs power-off $(instance_id $instance_name) 
+fi
 }
 
 reboot(){
 instance_name="$1"
-ibmcloud sl vs reboot $(instance_id $instance_name)
+force="$2"
+if [ "$force" == "true" ]
+then
+ibmcloud sl vs reboot $(instance_id $instance_name) --force
+else
+ibmcloud sl vs reboot $(instance_id $instance_name) 
+fi
 }
 
 get_image_id() {
@@ -316,8 +334,8 @@ create_instance() {
 instance_pretty() {
 	data=$(instances)
 	i=0
-        total=$(echo $data | jq -r '.[].billingItem.recurringFee  | select( . != null )' | awk '{sum+=$0} END{print sum}')
-	(echo "Instance,Primary Ip,Backend Ip,DC,Memory,CPU,Status,\$/M" && echo $data | jq  -r '.[] | [.hostname, .primaryIpAddress, .primaryBackendIpAddress, .datacenter.name, .maxMemory, .maxCpu, .powerState.name, .billingItem.recurringFee] | @csv' && echo "_,_,_,_,_,_,Total,\$$total") | sed 's/"//g' | column -t -s, | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
+        total=$(echo $data | jq -r '.[].billingItem.hourlyRecurringFee  | select( . != null )' | awk '{sum+=$0} END{print sum}')
+	(echo "Instance,Primary Ip,Backend Ip,DC,Memory,CPU,Status,Hours used,\$/H" && echo $data | jq  -r '.[] | [.hostname, .primaryIpAddress, .primaryBackendIpAddress, .datacenter.name, .maxMemory, .maxCpu, .powerState.name, .billingItem.hoursUsed, .billingItem.recurringFee] | @csv' && echo "_,_,_,_,_,_,_,Total,\$$total") | sed 's/"//g' | column -t -s, | perl -pe '$_ = "\033[0;37m$_\033[0;34m" if($. % 2)'
 }
 # Function used for splitting $src across $instances and rename the split files.
 lsplit() {


### PR DESCRIPTION
Multiple improvements in code readability and user experience as well as detailed help menus and small syntax changes.
Such as you no longer have to use `=` for command line syntax.

For example `axiom-fleet -i=5 --regions=nyc1,nyc3` is now `axiom-fleet -i 5 --regions nyc1,nyc3`.
`axiom-init stok01 --region=nyc3  --deploy=desktop`  is now   `axiom-init stok01 --region nyc3 --deploy desktop` and so on.
fixed broken arguments  in axiom-ssh, axiom-init and axiom-power.

below are some of the new help menu's

axiom-ssh
```
Description:
  axiom-ssh dynamically generates axiom's SSH config based on your cloud inventory.
  axiom-ssh allows you to connect to your axiom instances over their public or private network interface.
  axiom-ssh can drop you right into a freshly created tmux session on the remote instance, and can be used to
  attach to a preexisting tmux session.
  All additional SSH args are passed to SSH.
Examples:
  axiom-ssh testy01 # SSH into instance testy01
  axiom-ssh testy01 --tmux mysession1 # SSH into instance testy01 and spawn or attach to session named mysession1
  axiom-ssh --just-generate # Always populate axiom's ssh config (located in ~/.axiom/.sshconfig) with public Ip details
  axiom-ssh --just-generate private # Always populate axiom's ssh config (located in ~/.axiom/.sshconfig) with private Ip details
  axiom-ssh --just-generate cache # Never regenerate axiom's ssh config
  axiom-ssh testy01 -L 8080:127.0.0.1:8080 -D 4040  # Port-forward 8080 to local port 8080 and dynamically port foward port 4040 to testy01
Usage:
  <instance name> required string
    Instance name supplied as a positional first argument
  --mosh/-m <instance name> (optional)
    Connect with mosh
  --just_generate <public, private, cache> (optional)
    Specify when to generate the SSH config file and what IPs to use. Options are public, private, cache ( default is public )
  --tmux <tmux session name to create>
    Connect to your instance and start new tmux session. If you dont include a session name one will be chosen automatically for you
  --tmux-attach/-t <tmux session> (optional)
    Connect to your instance and attach to tmux session by name
  --cache (optional)
    Temporarily do not generate SSH config and instead connect with cached SSH config
  --help (optional)
    Display this help menu
  <additional args>
    All additional SSH args are passed to SSH. If you want additional arguments supplied to your command, simply append them to the command
    example: axiom-ssh <name> -L 8080:127.0.0.1:8080 -D 4040
```  

axiom-init --help
```
Description:
  Initialize one axiom instance with differnet options, such as image, region, size and axiom deployment profile
Examples:
  axiom-init # provision instance with random name
  axiom-init --deploy desktop # provision instance with random name, then deploy axiom profile 'desktop'
  axiom-init testy01 # provision instance named testy01
  axiom-init stok01 --region nyc3 --image axiom-barebones-1635920849 --size s-1vcpu-2gb --deploy desktop --shell
Usage:
  <name> string (optional)
    Name of the instance, supplied as a positional first argument
  --image <image name>
    Manually set the image to use (default is imageid in ~/.axiom/axiom.json)
  --region <region>
    User specified region to use (default is region in ~/.axiom/axiom.json)
  --deploy <profile>
    Deploy a profile after initialization (e.g desktop, openvpn, bbrf, wireguard)
  --shell (optional)
    Connect to instance after initialization
  --size <vm size>
    VM size to use  (default is size in ~/.axiom/account/account.json)
  --no-select (optional)
    Dont select instance after initialization (default is to select instance)
  --domain <example.com>
    Manually specify the domain to use (default is specified by cloud provider)
  --restore <backup>
    Initialize with a previous backup
  --help
    Display this help menu
```

axiom-fleet --help
```
Description:
  Spin up fleets of axiom instances in one or multiple regions.
  Specify the name of your fleet (fleet prefix) or have axiom choose for you.
Examples:
  axiom-fleet # Spin up three instances, let axiom decide on the fleet prefix
  axiom-fleet javis -i 10 # Spin up 10 instances with a fleet prefix of javis, this will create 10 instances named javis01 to javis10.
  axiom-fleet jerry -i 25 --regions nyc1,lon1,ams3,fra1 # Spin up 25 instances using round Robin region distribution
Usage:
  -i/--instances <integer>
    The number of instances to spin up
  -r/--regions <regions> (optional)
    Supply comma-separated regions to cycle through ( default get region from ~/.axiom/axiom.json)
  --help (optional)
    Display this help menu
```