### PR TITLE
Adjust default wordlist in puredns-bruteforce module

### DIFF
--- a/modules/puredns-bruteforce.json
+++ b/modules/puredns-bruteforce.json
@@ -1,6 +1,6 @@
 [{
     "command":"echo _target_ | /home/op/go/bin/puredns bruteforce _wordlist_ _target_ -r /home/op/lists/resolvers.txt  | tee _output_/_target_",
     "ext":"txt",
-    "wordlist":"/home/op/lists/2m-subdomains.txt",
+    "wordlist":"/home/op/lists/seclists/Discovery/DNS/dns-Jhaddix.txt",
     "threads":"1"
 }]


### PR DESCRIPTION
With `/home/op/lists/2m-subdomains.txt` not being available in the default image, this adjustment is made depicting the usage seen in the [Horizontal vs Vertical](https://github.com/pry0cc/axiom/wiki/Horizontal-vs-Vertical-Scaling#vertical-scaling---many-to-many) section of the wiki and felt a natural encounter. 

The idea is that an `axiom-scan targets.txt -m puredns-bruteforce` should run out of the box when using the `default.json` provisioner.