### PR TITLE
Add hakrevdns and delete trailing whitespaces at the end of the line in the default.json image file

### DIFF
--- a/images/provisioners/default.json
+++ b/images/provisioners/default.json
@@ -11,7 +11,7 @@
       "inline": [
         "echo 'Waiting for cloud-init to finish, this can take a few minutes please be patient...'",
         "/usr/bin/cloud-init status --wait",
-        
+
         "fallocate -l 2G /swap && chmod 600 /swap && mkswap /swap && swapon /swap",
         "echo '/swap none swap sw 0 0' | sudo tee -a /etc/fstab",
 
@@ -37,12 +37,12 @@
         "echo 'op:{{ user `op_random_password` }}' | chpasswd",
         "echo 'root:{{ user `op_random_password` }}' | chpasswd",
 
-        "echo 'Moving Config files'", 
+        "echo 'Moving Config files'",
         "systemctl disable systemd-resolved.service",
         "systemctl stop systemd-resolved.service",
-        "mv /tmp/configs/sudoers /etc/sudoers", 
+        "mv /tmp/configs/sudoers /etc/sudoers",
         "mv /tmp/configs/bashrc /home/op/.bashrc",
-        "mv /tmp/configs/zshrc /home/op/.zshrc",  
+        "mv /tmp/configs/zshrc /home/op/.zshrc",
         "mv /tmp/configs/sshd_config /etc/ssh/sshd_config",
         "mv /tmp/configs/00-header /etc/update-motd.d/00-header",
         "mv /tmp/configs/authorized_keys /home/op/.ssh/authorized_keys",
@@ -74,16 +74,16 @@
         "/bin/su -l root -c 'echo \"net.nf_conntrack_max = 1048576\" | sudo tee -a /etc/sysctl.conf'",
         "/bin/su -l root -c 'echo \"net.core.somaxconn = 1048576\" | sudo tee -a /etc/sysctl.conf'",
         "/bin/su -l root -c 'echo \"net.ipv4.ip_local_port_range = 1024 65535\" | sudo tee -a /etc/sysctl.conf'",
-        "/bin/su -l root -c 'echo \"1024 65535\" | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range'", 
-    
+        "/bin/su -l root -c 'echo \"1024 65535\" | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range'",
+
         "echo 'Installing Wordlists'",
 
         "echo 'Installing cent'",
         "git clone https://github.com/xm1k3/cent.git /home/op/lists/cent",
-        
+
         "echo 'Installing leaky-paths'",
         "git clone https://github.com/ayoubfathi/leaky-paths.git /home/op/lists/leaky-paths",
-       
+
         "echo 'Installing permutations'",
         "wget -q -O /home/op/lists/permutations.txt https://gist.github.com/six2dez/ffc2b14d283e8f8eff6ac83e20a3c4b4/raw",
 
@@ -91,16 +91,16 @@
         "git clone https://github.com/danielmiessler/SecLists.git /home/op/lists/seclists",
 
         "echo 'Installing resolvers'",
-        "wget -q -O /home/op/lists/resolvers.txt https://raw.githubusercontent.com/janmasarik/resolvers/master/resolvers.txt",        
-        
-        "echo 'Installing Tools'", 
-   
+        "wget -q -O /home/op/lists/resolvers.txt https://raw.githubusercontent.com/janmasarik/resolvers/master/resolvers.txt",
+
+        "echo 'Installing Tools'",
+
         "echo 'Installing aiodnsbrute'",
         "git clone https://github.com/blark/aiodnsbrute.git /home/op/recon/aiodnsbrute",
 
         "echo 'Installing anew'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/tomnomnom/anew@latest'",
-        
+
         "echo 'Installing anti-burl'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/tomnomnom/hacks/anti-burl@latest'",
 
@@ -135,7 +135,7 @@
         "/bin/su -l op -c 'git clone https://github.com/s0md3v/Corsy.git /home/op/recon/Corsy && cd /home/op/recon/Corsy && pip3 install -r requirements.txt && cd'",
 
         "echo 'Installing CrackMapExec'",
-        "wget -q -O /tmp/cme-ubuntu-latest.zip https://github.com/byt3bl33d3r/CrackMapExec/releases/download/v5.1.7dev/cme-ubuntu-latest.zip && unzip /tmp/cme-ubuntu-latest.zip -d /home/op/recon/ && chmod +x /home/op/recon/cme", 
+        "wget -q -O /tmp/cme-ubuntu-latest.zip https://github.com/byt3bl33d3r/CrackMapExec/releases/download/v5.1.7dev/cme-ubuntu-latest.zip && unzip /tmp/cme-ubuntu-latest.zip -d /home/op/recon/ && chmod +x /home/op/recon/cme",
 
         "echo 'Installing crlfuzz'",
         "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest'",
@@ -160,7 +160,7 @@
 
         "echo 'Installing dnsx'",
         "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
-   
+
         "echo 'Installing ERLPopper'",
         "git clone https://github.com/maikthulhu/ERLPopper.git /home/op/recon/ERLPopper",
 
@@ -169,7 +169,7 @@
 
         "echo 'Installing feroxbuster'",
         "/bin/su -l root -c 'curl -sL https://raw.githubusercontent.com/epi052/feroxbuster/master/install-nix.sh | bash && mv feroxbuster /usr/bin/'",
-        
+
         "echo 'Installing fff'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/tomnomnom/fff@latest'",
 
@@ -183,14 +183,14 @@
         "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/lc/gau@latest'",
 
         "echo 'Installing gauplus'",
-        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install -v github.com/bp0lr/gauplus@latest'",  
-        
+        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install -v github.com/bp0lr/gauplus@latest'",
+
         "echo 'Installing getJS'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/003random/getJS@latest'",
 
         "echo 'Installing gf'",
         "/bin/su -l op -c 'GO111MODULE=off /usr/local/go/bin/go install github.com/tomnomnom/gf@latest'",
-        
+
         "echo 'Installing Gf-Patterns'",
         "git clone https://github.com/1ndianl33t/Gf-Patterns /home/op/.gf",
 
@@ -201,10 +201,10 @@
         "cd /tmp && wget -q -O /tmp/gobuster.7z https://github.com/OJ/gobuster/releases/download/v3.1.0/gobuster-linux-amd64.7z && p7zip -d /tmp/gobuster.7z && sudo mv /tmp/gobuster-linux-amd64/gobuster /usr/bin/gobuster && sudo chmod +x /usr/bin/gobuster",
 
         "echo 'Installing google-chrome'",
-        "wget -q -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && cd /tmp/ && sudo apt install -y /tmp/chrome.deb -qq && apt --fix-broken install -qq",         
+        "wget -q -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && cd /tmp/ && sudo apt install -y /tmp/chrome.deb -qq && apt --fix-broken install -qq",
 
         "echo 'Installing gorgo'",
-        "/bin/su -l op -c 'git clone https://github.com/pry0cc/gorgo.git /home/op/recon/gorgo && pip3 install -r /home/op/recon/gorgo/requirements.txt'", 
+        "/bin/su -l op -c 'git clone https://github.com/pry0cc/gorgo.git /home/op/recon/gorgo && pip3 install -r /home/op/recon/gorgo/requirements.txt'",
 
         "echo 'Installing gospider'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/jaeles-project/gospider@latest'",
@@ -220,6 +220,9 @@
 
         "echo 'Installing hakrawler'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/hakluke/hakrawler@latest'",
+
+        "echo 'Installing hakrevdns'",
+        "/bin/su -l op -c '/usr/local/go/bin/go install github.com/hakluke/hakrevdns@latest'",
 
         "echo 'Installing httprobe'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/tomnomnom/httprobe@latest'",
@@ -247,7 +250,7 @@
 
         "echo 'Installing massdns'",
         "git clone https://github.com/blechschmidt/massdns.git /tmp/massdns; cd /tmp/massdns; make -s; sudo mv bin/massdns /usr/bin/massdns",
-        
+
         "echo 'Installing medusa'",
         "apt install medusa -y -qq",
 
@@ -265,7 +268,7 @@
         "git clone --depth 1  https://github.com/ivre/ivre.git /home/op/recon/nmap_scripts && cd /home/op/recon/nmap_scripts && git filter-branch --prune-empty --subdirectory-filter  nmap_scripts HEAD",
         "sudo cp /home/op/recon/nmap_scripts/* /usr/local/share/nmap/scripts && sudo nmap --script-update",
         "sudo cp /home/op/recon/nmap_scripts/* /home/op/recon/nmap/scripts/ && cd /home/op/recon/nmap && sudo ./nmap --script-update",
-        
+
         "echo 'Installing nuclei'",
         "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest && /home/op/go/bin/nuclei'",
 

--- a/modules/hakrevdns.json
+++ b/modules/hakrevdns.json
@@ -1,0 +1,4 @@
+[{
+    "command":"cat input | /home/op/go/bin/hakrevdns | tee output",
+    "ext":"txt"
+}]


### PR DESCRIPTION
[hakrevdns](https://github.com/hakluke/hakrevdns) is a tool that allow to find a subdomain given an Ip address, in other words, reverse dns. 

Usage example: 
You can generate a test `ips.txt` file from the same cidr used in the hakrevdns repository to test this PR

```bash
prips 173.0.84.0/24 > ips.txt
```
then call `axiom-scan`:
```bash
axiom-scan ips.txt -m hakrevdns -t 1000 -o out.txt
```



