### PR TITLE
calling detect to make module work

### DIFF
--- a/modules/http2smugl.json
+++ b/modules/http2smugl.json
@@ -1,4 +1,4 @@
 [{
-	"command":"http2smugl --targets input --csv-log output",
+	"command":"http2smugl detect --targets input --csv-log output",
 	"ext":"csv"
 }]


### PR DESCRIPTION
http2smugl has a command that needs calling for it to work. It was throwing an error as written. detect made the most sense of the two base on how it is run. 