### PR TITLE
axiom-exec refactor 

### DIFF
--- a/interact/axiom-adduser
+++ b/interact/axiom-adduser
@@ -13,5 +13,5 @@ $AXIOM_PATH/interact/axiom-ssh --just-generate
 
 for instance in $instances
 do
-	 $AXIOM_PATH/interact/axiom-exec "$command" "$instance" --cache 
+	 $AXIOM_PATH/interact/axiom-exec "$command" -i "$instance" --cache 
 done

--- a/interact/axiom-deploy
+++ b/interact/axiom-deploy
@@ -76,7 +76,7 @@ do
         if [[ "$count" -gt 1 ]]; then
             echo -e "${BWhite}Uploading profile to '$query'${Color_Off}${Blue}"
             axiom-scp "$script" "$query":"/tmp/$id.sh" --cache
-            axiom-exec "/tmp/$id.sh" "$query" --cache
+            axiom-exec "/tmp/$id.sh" -i "$query" --cache
             echo -e "${BGreen}Installation Successful!${Color_Off}"
             echo -e "${BWhite}Notes${Color_Off}${Blue}"
             jq -r ".notes" "$prof_path"

--- a/interact/axiom-exec
+++ b/interact/axiom-exec
@@ -283,10 +283,10 @@ trap clean_up SIGINT SIGTERM
 # Disable progress bar, reduce verbosity, only terminal output of the command is returned to terminal
 #
 if [[ "$nobar" == "false" ]]; then
- $interlace_cmd -c "$ssh_command _target_ '$commands'" 
+ $interlace_cmd -c "$ssh_command _target_ '$commands 1>&2'" 
  pid=$1
 else
- $interlace_cmd_nobar -c "$ssh_command _target_  '$commands'" | grep -v 'commands in total' | grep -v 'Repeat set to'
+ $interlace_cmd_nobar -c "$ssh_command _target_  '$commands 1>&2'" | grep -v 'commands in total' | grep -v 'Repeat set to'
  pid=$1
 fi
 

--- a/interact/axiom-exec
+++ b/interact/axiom-exec
@@ -1,113 +1,299 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+###################################################################
+# Title : axiom-exec
+#
+#Description:
+#  Evaluate shell one-liners or execute single commands on one or more instances in parallel                                                                                                                                                
+#  Expand local and remote environment variables respectively                                                                                                                                                                               
+#  Specify the fleet prefix, or let axiom use selected.conf by default (located in ~/.axiom/selected.conf)                                                                                                                                  
+#  Optionally execute command(s) in a detached tmux session on the remote instances (commands run in the background)                                                                                                                        
+#  Temporarily prevent axiom's SSH key regeneration and instead connect with a cached SSH config (default is ~/.axiom/.sshconfig)                                                                                                           
+#Examples:                                                                                                                                                                                                                                  
+#  axiom-exec id  # Execute command id across all instances currently selected.conf (located in ~/.axiom/selected.conf)
+#  axiom-exec 'sleep $(($RANDOM % 10)) && echo done' --instance testy01  # Evaluate complex one-liners on instance named tasty01
+#  axiom-exec ifconfig --fleet testy  # Execute ifconfig on testy fleet. Automatically select all instances in fleet testy.
+#  axiom-exec 'sleep 10' -q --cache --fleet OtherFleet --tmux MySession01  # Quietly execute command(s) inside a detacted tmux session on the remote instances with custom session name.
+#  axiom-exec whoami -q --cache --sshconfig ~/.axiom/log/exec/axiom-exec+1234567890/sshconfig --fleet oldfleet --tmux  # Specify the axiom SSH config to use (default is ~/.axiom/.sshconfig)
+#Usage:
+#  <commands> required string
+#    Command(s) to run on the remote axiom instances, multiple commands must be wrapped in single or double quotes.
+#  -f/--fleet <fleet prefix>
+#    Fleet prefix to execute on (default is ~/.axiom/selected.conf). Automatic wildcard support.
+#  -i/--instance <instance name>
+#    Single instance to execute on.
+#  --tmux <optional tmux session name>
+#    Execute commands in a detacted tmux session (commands run in the background). The default tmux session name is axiom-exec+$TIMESTAMP, or supply a custom tmux session name.
+#  --sshconfig <sshconfig_file> (optional string)
+#    Path to axiom's SSH config (default is ~/.axiom/.sshconfig)
+#  -q/--quiet
+#    Disable progress bar, and reduce verbosity
+#  --debug
+#    Enable debug mode (VERY VERBOSE!)
+#  --cache
+#    Temporarily do not generate SSH config and instead connect with cached SSH config
+#  --logs
+#    Do not delete logs (logs will be stored in ~/.axiom/logs/exec/axiom-exec$TIMESTAMP).
+#  --help
+#    Display this help menu
+
+###########################################################################################################
+# Header
+#
 AXIOM_PATH="$HOME/.axiom"
 source "$AXIOM_PATH/interact/includes/vars.sh"
 source "$AXIOM_PATH/interact/includes/functions.sh"
-rm -r "$HOME/.ssh/sockets" > /dev/null 2>&1
-mkdir -p "$HOME/.axiom/tmp"
-function help() {
-        echo -e "${BWhite}Usage of axiom-exec${Color_Off}"
-        echo -e "Example Usage: ${Blue}axiom-exec 'id' 'my-fleet*' --cache${Color_Off}"
-        echo -e "  <commands> required positional string"
-        echo -e "   Commands to run on the remote axiom instances, wrapped in single or double quotes"
-        echo -e "  <fleet prefix> positional string"
-        echo -e "   The instance or fleet name to execute the command on, supports wildcard (i.e myfleet*), wrapped in signle or double quotes"
-        echo -e "  --cache positional option"
-        echo -e "    Use SSH cache (works if recently interacted with)"
-} 
+source "$AXIOM_PATH/interact/includes/system-notification.sh"
+begin=$(date +%s)
+start="$(pwd)"
+BASEOS="$(uname)"
+account_path=$(ls -la "$AXIOM_PATH"/axiom.json | rev | cut -d " " -f 1 | rev)
+accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
+current=$(ls -lh ~/.axiom/axiom.json | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
+case $BASEOS in
+'Darwin')
+    PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
+    ;;
+*) ;;
+esac
 
-if [[ "$@" == "--help" ]] || [[ "$@" == "-h" ]] || [[ "$@" == "" ]]; then
-help
-exit
-fi
-
-droplets=$(instances)
-selected=$(cat $AXIOM_PATH/selected.conf)
-quiet=false
-query=""
-args=""
+###########################################################################################################
+# Declare defaut variables
+#
+set=false
+sshkey=$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey | select( . != null )')
 cache=false
-command="$1"
+quiet=false
+starttime=$(date +"%F-TIME-%T")
+uid="axiom-exec+$(date +%s)"
+tmp="$AXIOM_PATH/tmp/exec/$uid"
+logs="$AXIOM_PATH/logs/exec/$uid"
+sshconfig="$AXIOM_PATH/.sshconfig"
+debug=false
+nobar=false
+use_tmux=false
+instance=false
+keep_logs=false
 
-for var in "$@"
+###########################################################################################################
+# Help Menu:
+# TODO add sshkey option to specify ssh key used to authenticate
+# TODO add executing commands from a file
+# TODO add axiom-scp extention for arb upload and download
+#
+function usage() {
+        echo -e "${BWhite}Description:"
+        echo -e "  Evaluate shell one-liners or execute single commands on one or more instances in parallel" 
+        echo -e "  Expand local and remote environment variables respectively"
+        echo -e "  Specify the fleet prefix, or let axiom use selected.conf by default (located in ~/.axiom/selected.conf)"
+        echo -e "  Optionally execute command(s) in a detached tmux session on the remote instances (commands run in the background)" 
+        echo -e "  Temporarily prevent axiom's SSH key regeneration and instead connect with a cached SSH config (default is ~/.axiom/.sshconfig)" 
+        echo -e "${BWhite}Examples:${Color_Off}"
+        echo -e "  ${Blue}axiom-exec id ${Color_Off}# Execute command id across all instances currently selected.conf (located in ~/.axiom/selected.conf)"
+        echo -e "  ${Blue}axiom-exec 'sleep \$((\$RANDOM % 10)) && echo done' --instance testy01 ${Color_Off}# Evaluate complex one-liners on instance named tasty01"
+        echo -e "  ${Blue}axiom-exec ifconfig --fleet testy ${Color_Off}# Execute ifconfig on testy fleet. Automatically select all instances in fleet testy."
+        echo -e "  ${Blue}axiom-exec 'sleep 10' -q --cache --fleet OtherFleet --tmux MySession01 ${Color_Off}# Quietly execute command(s) inside a detacted tmux session on the remote instances with custom session name." 
+        echo -e "  ${Blue}axiom-exec whoami -q --cache --sshconfig ~/.axiom/log/exec/axiom-exec+1234567890/sshconfig --fleet oldfleet --tmux ${Color_Off}# Specify the axiom SSH config to use (default is ~/.axiom/.sshconfig)"
+        echo -e "${BWhite}Usage:${Color_Off}"
+        echo -e "  <commands> required string"
+        echo -e "    Command(s) to run on the remote axiom instances, multiple commands must be wrapped in single or double quotes."
+        echo -e "  -f/--fleet <fleet prefix>"
+        echo -e "    Fleet prefix to execute on (default is ~/.axiom/selected.conf). Automatic wildcard support."   
+        echo -e "  -i/--instance <instance name>"
+        echo -e "    Single instance to execute on."
+        echo -e "  --tmux <optional tmux session name>"
+        echo -e "    Execute commands in a detacted tmux session (commands run in the background). The default tmux session name is axiom-exec+\$TIMESTAMP, or supply a custom tmux session name."
+        echo -e "  --sshconfig <sshconfig_file> (optional string)"
+        echo -e "    Path to axiom's SSH config (default is ~/.axiom/.sshconfig)"
+        echo -e "  -q/--quiet"
+        echo -e "    Disable progress bar, and reduce verbosity"
+        echo -e "  --debug"
+        echo -e "    Enable debug mode (VERY VERBOSE!)"
+        echo -e "  --cache"
+        echo -e "    Temporarily do not generate SSH config and instead connect with cached SSH config"
+        echo -e "  --logs"
+        echo -e "    Do not delete logs (logs will be stored in ~/.axiom/logs/exec/axiom-exec\$TIMESTAMP)."
+        echo -e "  --help"
+        echo -e "    Display this help menu"
+}
+
+###########################################################################################################
+# Parse command line arguments 
+#
+i=0
+for arg in "$@"
 do
-    if [ "$var" == "--cache" ]
-    then
-		cache=true
-	elif [ "$var" == "--quiet" ]
-	then
-		quiet=true
-	elif [ "$var" == "-q" ]
-	then
-		quiet=true
-	elif [ "$var" == "-t" ]
-	then
-		args="-t"
-	fi
-done
-
-if [ $cache != "true" ]
-then
-	generate_sshconfig
-fi
-
-if [ ! -z "$2" ]
-then
-    query="$2"
-    if [[ "$query" =~ "*" ]]
-    then
-		selected=$(query_instances_cache "$query")
-    else
-    	selected="$query"
-    fi
-fi
-
-if [ -z "$1" ]
-then
-    echo "Provide an argument n00b!"
-    exit 0
-fi
-
-total=$(echo $selected | tr ' ' '\n' | wc -l | awk '{ print $1 }')
-cmds_file="$AXIOM_PATH/tmp/$RANDOM-$RANDOM-cmd.txt"
-full=""
-
-touch $cmds_file
-
-i=1
-for name in $selected
-do
-    if [[ "$quiet" != "true" ]]
-    then
-        echo -n -e "${Blue}" 
-    fi
-
-    cmd="$1"
-    rendered=$(echo $cmd | sed "s/\$i/$i/g" | sed "s/\$name/$name/g" | sed "s/\$total/$total/g")
-
-    sshkey=$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey | select( . != null )') 
-     if [ -z "$sshkey" ]
-    then
-      sshkey="id_rsa"
-    fi
-    full="ssh -i "~/.ssh/$sshkey" -F $AXIOM_PATH/.sshconfig -o StrictHostKeyChecking=no \"$name\" $args \"$rendered\""
-    echo "$full" >> $cmds_file
-	
     i=$((i+1))
+    if [[  ! " ${pass[@]} " =~ " ${i} " ]]; then
+        set=false
+        if [[ "$arg" == "--fleet" ]] || [[ "$arg" == "-f" ]] ; then
+            n=$((i+1))
+            fleet=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--instance" ]] || [[ "$arg" == "-i" ]] ; then
+            n=$((i+1))
+            instance=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--tmux" ]]; then
+            n=$((i+1))
+            use_tmux=true
+            tmux_session_name=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--sshconfig" ]]; then
+            n=$((i+1))
+            sshconfig=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]]; then
+            usage
+            exit
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--debug" ]]; then
+            debug=true
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--cache" ]]; then
+            cache=true
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--logs" ]]; then
+            keep_logs=true
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--quiet" ]] || [[ "$arg" == "-q" ]]; then
+            nobar=true
+            set=true
+            pass+=($i)
+        fi
+        if  [[ "$set" != "true" ]]; then
+            args="$args $arg"
+        fi
+    fi
 done
 
-if [[ $total -gt 1 ]]
-then
-	if [[ "$quiet" != "true" ]]
-	then
-    	echo -e "${BWhite}Executing parallel on fleet $name*...${Color_Off}"
-	fi
-	interlace -cL "$cmds_file" -t NULL -threads $i
-else
-	if [[ "$quiet" != "true" ]]
-	then
-		echo -e "${BWhite}Executing on $name...${Color_Off}"
-	fi
-	bash -c "$full"
+###########################################################################################################
+# clean_up
+#
+clean_up() {
+kill -9 $pid >/dev/null 2>&1 
+}
+
+###########################################################################################################
+# Debug Flag
+#
+if [[ "$debug" == "true" ]]; then
+ set -xv
+fi 
+
+###########################################################################################################
+# Display Help Menu
+#
+if [[ "$*" == "--help" ]] || [[ "$*" == "-h" ]] || [[ "$*" == "" ]]; then
+ usage
+ exit
 fi
 
-rm $cmds_file
+###########################################################################################################
+# SSH Cache Flag
+#
+if [[ "$cache" == "false" ]]; then
+ generate_sshconfig
+fi
+
+###########################################################################################################
+# Store $args in $commands
+# 
+commands="$args"
+
+###########################################################################################################
+# If --tmux is in the command, connect to instance and spawn a new tmux session
+#
+if [[ $use_tmux == true ]] ;then
+ if [[ -z ${tmux_session_name:+x} ]]; then
+  tmux_session_name=$uid
+ fi
+ commands="tmux new-session -d -s $tmux_session_name \""$commands"\""
+fi
+
+###########################################################################################################
+# Make a copy of the current SSH config plus selected.conf and use them for axiom-exec
+#
+mkdir -p "$tmp/logs"
+printf "%s" "$commands" > "$tmp"/commands.txt
+cat "$AXIOM_PATH/selected.conf" >> "$tmp/hosts"
+cp "$sshconfig" "$tmp/sshconfig" 
+sshconfig="$tmp/sshconfig"
+total_instances="$(wc -l "$tmp/hosts" | awk '{ print $1 }')"
+
+###########################################################################################################
+# If --fleet isnt provided, default to selected.conf
+#
+if [[ -z ${fleet:+x} ]]; then
+ instances=$(cat "$tmp/hosts")
+else
+ if [[ -f "$fleet" ]] ; then
+  instances=$(cat "$fleet")
+  echo "$instances" | tr ' ' '\n' > "$tmp/hosts"
+  total_instances="$(wc -l "$tmp/hosts" | awk '{ print $1 }')"
+ else
+  instances=$(query_instances_cache "$fleet*")
+  echo "$instances" | tr ' ' '\n' > "$tmp/hosts"
+  total_instances="$(wc -l "$tmp/hosts" | awk '{ print $1 }')"
+ fi
+fi
+###########################################################################################################
+# If --instance is provided, add it to total instances
+#
+if [[ $instance != false ]]; then
+ name=$(query_instances_cache "$instance")
+ echo "$name" | tr ' ' '\n' > "$tmp/hosts"
+ total_instances="$(wc -l "$tmp/hosts" | awk '{ print $1 }')"
+fi
+
+###########################################################################################################
+# Prepare the default SSH and interlace command and execute the user provided command in parallel
+#
+ssh_command="ssh -F $sshconfig -o StrictHostKeyChecking=no"
+interlace_cmd="$(which interlace) --silent -tL $tmp/hosts -threads $total_instances"
+interlace_cmd_nobar="$(which interlace) --no-bar --silent -tL $tmp/hosts -threads $total_instances"
+
+###########################################################################################################
+# Prevents Interlace hangups from hijacking your terminal  
+#
+stty -echoctl
+trap clean_up SIGINT SIGTERM
+
+###########################################################################################################
+# Disable progress bar, reduce verbosity, only terminal output of the command is returned to terminal
+#
+if [[ "$nobar" == "false" ]]; then
+ $interlace_cmd -c "$ssh_command _target_ '$commands'" 
+ pid=$1
+else
+ $interlace_cmd_nobar -c "$ssh_command _target_  '$commands'" | grep -v 'commands in total' | grep -v 'Repeat set to'
+ pid=$1
+fi
+
+###########################################################################################################
+# keep logs flag aka --logs
+#
+mv "$tmp" "$logs">/dev/null 2>&1
+if [[ $keep_logs != true ]]; then
+ rm -r $logs >/dev/null 2>&1
+fi

--- a/interact/axiom-init
+++ b/interact/axiom-init
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###########################################################################################################
-# Title	: axiom-init
+# Title : axiom-init
 # About: Initialize axiom instances with differnet options, such as image, region, size and axiom deployment profile
 #
 # Examples: 
@@ -253,7 +253,7 @@ waitabit "$PID"
 sleep 20
 ip="$(instance_ip "$name")"
 ssh-keygen -R "[$ip]:2266" >>  /dev/null 2>&1
-axiom-exec "touch /tmp/.connected && echo $(echo "$name" | tr -d "'") | tee /home/op/.name" "$name" -q >> /dev/null 2>&1
+axiom-exec "touch /tmp/.connected && echo $(echo "$name" | tr -d "'") | tee /home/op/.name" -i "$name" -q >> /dev/null 2>&1
 echo -e "${BWhite}Initialized instance '${BGreen}$name${Color_Off}${BWhite}' at '${BGreen}$ip${BWhite}'!"
 else
 
@@ -282,7 +282,7 @@ done
 
 ip="$(instance_ip "$name")"
 ssh-keygen -R "[$ip]:2266" >>  /dev/null 2>&1
-axiom-exec "touch /tmp/.connected && echo $(echo "$name" | tr -d "'") | tee /home/op/.name" "$name" -q >> /dev/null 2>&1
+axiom-exec "touch /tmp/.connected && echo $(echo "$name" | tr -d "'") | tee /home/op/.name" -i "$name" -q >> /dev/null 2>&1
 echo -e "${BWhite}Initialized instance '${BGreen}$name${Color_Off}${BWhite}' at '${BGreen}$ip${BWhite}'!"
 echo -e "${BWhite}To connect, run '${BGreen}axiom-ssh $name${Color_Off}'${BWhite} or '${BGreen}axiom-connect'${Color_Off}"
 "$NOTIFY_CMD" "Axiom Info" "$name successfully initialized at $ip!"
@@ -299,16 +299,14 @@ fi
 # restore flag
 #
 if [ "$restore" != false ]; then
-	#echo -e "${BWhite}Waiting 65 seconds before restore...${Color_Off}"
-	"$AXIOM_PATH"/interact/axiom-restore "$restore" "$name"
+"$AXIOM_PATH"/interact/axiom-restore "$restore" "$name"
 fi
 
 ###########################################################################################################
 # deploy flag
 #
 if [ "$deploy" != false ]; then
-	#echo -e "${BWhite}Waiting 65 seconds before deploy... ${Color_Off}"
-	"$AXIOM_PATH"/interact/axiom-deploy "$deploy" "$name"
+"$AXIOM_PATH"/interact/axiom-deploy "$deploy" "$name"
 fi
 
 ###########################################################################################################

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -149,16 +149,17 @@ clean_up() {
 }
 
 ###########################################################################################################
-#  axiom can take up a lot of space with logs. When --rm-logs option is present, after the scan is finished or canceled, axiom-orgalorg will delete the remote logs.
+#  axiom can take up a lot of space with logs. When --rm-logs option is present, after the scan is finished or canceled, axiom-exec will delete the remote logs.
 #  To avoid undesirable scan results after merging, we keep the original un-merged scan result as well as the final merged copy. Everything else pertaining to the scan deleted.
 delete_logs() {
  echo -e "${Blue}Deleting remote logs in a backgroud job${Color_Off}"
- axiom-orgalorg -C "sudo rm -r /home/op/scan/${uid}/" -i "$(cat $AXIOM_PATH/logs/$uid/selected.conf | tr '\n' " " )" >/dev/null 2>&1 &
+ axiom-exec "sudo rm -r /home/op/scan/${uid}/" --fleet "$AXIOM_PATH/logs/$uid/selected.conf"  >/dev/null 2>&1 &
   if [ -d "$AXIOM_PATH/logs/$uid/" ] 
    then
    echo -e "${Blue}Deleting local logs, except for $AXIOM_PATH/logs/$uid/output/ ${Color_Off}"
    start=$(pwd)
-   cd "$AXIOM_PATH/logs/$uid/" ; ls | grep -v output | xargs rm -r >/dev/null 2>&1
+   cd "$AXIOM_PATH/logs/$uid/" || exit 
+   ls | grep -v output | xargs rm -r >/dev/null 2>&1
    cd "$start"
   else
     echo "Error: local log folder does not exist."

--- a/interact/axiom-wait
+++ b/interact/axiom-wait
@@ -19,7 +19,7 @@ command="$1"
 exit=1
 while [[ "$exit" -gt 0 ]]
 do 
-	exit=$(axiom-exec "ps cax | pgrep "$command" | wc -l | awk '{ print \$1 }'" "$instance" -q)
+	exit=$(axiom-exec "ps cax | pgrep "$command" | wc -l | awk '{ print \$1 }'" -i "$instance" -q)
 
 	sleep $(expr $RANDOM % 20)
 done

--- a/profiles/ivre.json
+++ b/profiles/ivre.json
@@ -44,7 +44,7 @@
 "echo ''",
 "echo 'The IVRE / DRUNK Dynamic Recon of UNKnown Network Install Complete'",
 "echo 'To start the dashbaord:'",
-"echo \"run axiom-exec 'docker run -d --name ivreweb --hostname ivreweb --link ivredb:ivredb --publish 80:80 ivre/web' '$(hostname)'\"",
+"echo \"run axiom-exec 'docker run -d --name ivreweb --hostname ivreweb --link ivredb:ivredb --publish 80:80 ivre/web' -i '$(hostname)'\"",
 "echo 'Then the dashboard will be publicly reachable at:'",
 "dig @ns1-1.akamaitech.net ANY whoami.akamai.net +short | sed 's/^/http:/'"
     ],


### PR DESCRIPTION
This brings a lot of new features and functionality with one small syntax change. By default execute on the instances listed in `~/.axiom/selected.conf`, but to choose a different fleet or instance you now specify the instance/fleet with arguments `-i/--instance` or `-f/--fleet`. 

- detailed help menu
- ability to execute complex one-liners
- ability to expand local or remote env variables in the same command
- background execution support with tmux
- beta interactive command line execution in series 

this also brings a beta version of interactive command line execution, such as, I was able to run the following (as an illustrative example )
``` 
axiom-exec 'bash <(curl -s https://raw.githubusercontent.com/pry0cc/axiom/master/interact/axiom-configure)'
```
using axiom-exec to install axiom and interactively provide user input, like API keys and cloud provider details etc in real time. This also works with a fleet (press enter to cycle through the instances) but can be somewhat challenging atm however I was able to interactively configure 3 controllers simultaneously and run axiom-build etc all in one axiom-exec.

```
Description:
  Evaluate shell one-liners or execute single commands on one or more instances in parallel                                                                                                                       
  Expand local and remote environment variables respectively                                                                                                                                                      
  Specify the fleet prefix, or let axiom use selected.conf by default (located in ~/.axiom/selected.conf)                                                                                                         
  Optionally execute command(s) in a detached tmux session on the remote instances (commands run in the background)                                                                                               
  Temporarily prevent axiom's SSH key regeneration and instead connect with a cached SSH config (default is ~/.axiom/.sshconfig)                                                                                  
Examples:                                                                                                                                                                                                         
  axiom-exec id # Execute command id across all instances currently selected.conf (located in ~/.axiom/selected.conf)
  axiom-exec 'sleep $(($RANDOM % 10)) && echo done' --instance testy01 # Evaluate complex one-liners on instance named tasty01
  axiom-exec ifconfig --fleet testy # Execute ifconfig on testy fleet. Automatically select all instances in fleet testy.
  axiom-exec 'sleep 10' -q --cache --fleet OtherFleet --tmux MySession01 # Quietly execute command(s) inside a detacted tmux session on the remote instances with custom session name.
  axiom-exec whoami -q --cache --sshconfig ~/.axiom/log/exec/axiom-exec+1234567890/sshconfig --fleet oldfleet --tmux # Specify the axiom SSH config to use (default is ~/.axiom/.sshconfig)
Usage:
  <commands> required string
    Command(s) to run on the remote axiom instances, multiple commands must be wrapped in single or double quotes.
  -f/--fleet <fleet prefix>
    Fleet prefix to execute on (default is ~/.axiom/selected.conf). Automatic wildcard support.
  -i/--instance <instance name>
    Single instance to execute on.
  --tmux <optional tmux session name>
    Execute commands in a detacted tmux session (commands run in the background). The default tmux session name is axiom-exec+$TIMESTAMP, or supply a custom tmux session name.
  --sshconfig <sshconfig_file> (optional string)
    Path to axiom's SSH config (default is ~/.axiom/.sshconfig)
  -q/--quiet
    Disable progress bar, and reduce verbosity
  --debug
    Enable debug mode (VERY VERBOSE!)
  --cache
    Temporarily do not generate SSH config and instead connect with cached SSH config
  --logs
    Do not delete logs (logs will be stored in ~/.axiom/logs/exec/axiom-exec$TIMESTAMP).
  --help
    Display this help menu

```

![new-axiom-exec-help-menu](https://user-images.githubusercontent.com/21030907/150478195-97569ec5-2d19-4c2e-8121-85ad28e6e7e9.png)



