### PR TITLE
Update axiom-configure

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -69,7 +69,6 @@ function omz_shell(){
     echo -e "${Blue}Backing up $(echo "$HOME"/.zshrc) to $(echo "$HOME"/.zshrcbak) just in case.${Color_Off}"
     cp "$HOME"/.zshrc "$HOME"/.zshrcbak >> /dev/null 2>&1
     sudo apt install zsh zsh-syntax-highlighting zsh-autosuggestions -y
-    wget -q https://raw.githubusercontent.com/pry0cc/axiom/master/configs/kali-zshrc -O ~/.zshrc -q
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
     if ! [ -x "$(command -v go)" ]; then
     echo -e "${Blue}Installing Golang${Color_Off}"


### PR DESCRIPTION
The default template of `. zshrc` works best, as the one that is downloaded breaks the ability to set a new Oh My Zsh theme via `ZSH_THEME=` and more things.

To test this:

```
rm  ~/.zshrc
cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc

echo "export GOPATH=\$HOME/go" >>~/.zshrc
echo "export PATH=\$GOPATH/bin:/usr/local/go/bin:\$PATH:\$HOME/.local/bin"  >>~/.zshrc
echo "export PATH=\$GOPATH/bin:/usr/local/go/bin:\$PATH" >>~/.zshrc
echo -e "${Green}You're running ZSH! Installing Axiom to \$PATH...${Color_Off}"
echo "export PATH=\"\$PATH:\$HOME/.axiom/interact\"" >>~/.zshrc  
echo "source $HOME/.axiom/functions/autocomplete.zsh" >>~/.zshrc 
```