### PR TITLE
better sshconfig control

### DIFF
--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -567,6 +567,12 @@ if [[ "$spinup" -gt 0 ]]; then
     sleep 60
 fi
 
+# SSH Cache Flag
+#
+if [[ "$cache" == "false" ]]; then
+    generate_sshconfig
+fi
+
 # Not sure why we cat and then cp the selected.conf to different file names
 # Make a copy of the current SSH config and use it for axiom-scan
 #
@@ -620,12 +626,6 @@ fi
 
 if [[ "$module" == "gowitness" ]]; then
     ext=""
-fi
-
-# SSH Cache Flag
-#
-if [[ "$cache" == "false" ]]; then
-    generate_sshconfig
 fi
 
 # Variables to display about the scan

--- a/providers/azure-functions.sh
+++ b/providers/azure-functions.sh
@@ -266,20 +266,21 @@ query_instances_cache() {
 # take no arguments, generate a SSH config from the current Digitalocean layout
 generate_sshconfig() {
 	boxes="$(az vm list-ip-addresses --resource-group axiom)"
-	echo -n "" > $AXIOM_PATH/.sshconfig.new
-	echo -e "\tServerAliveInterval 60\n" >> $AXIOM_PATH/.sshconfig.new
-  echo -e "\tServerAliveCountMax 60\n" >> $AXIOM_PATH/.sshconfig.new
+        sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
+	echo -n "" > "$sshnew"
+	echo -e "\tServerAliveInterval 60\n" >> $sshnew
+  echo -e "\tServerAliveCountMax 60\n" >> $sshnew
   sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-  echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $AXIOM_PATH/.sshconfig.new
+  echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
 
     
 	for name in $(echo "$boxes" | jq -r '.[].virtualMachine.name')
 	do 
 		ip=$(echo "$boxes" | jq -r ".[].virtualMachine | select(.name==\"$name\") | .network.publicIpAddresses[].ipAddress")
-		echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+		echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
 
 	done
-	mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+	mv $sshnew $AXIOM_PATH/.sshconfig
 	
 	if [ "$key" != "null" ]
 	then

--- a/providers/do-functions.sh
+++ b/providers/do-functions.sh
@@ -263,12 +263,13 @@ query_instances_cache() {
 generate_sshconfig() {
 accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
 current=$(ls -lh ~/.axiom/axiom.json | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
+sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
 droplets="$(instances)"
-echo -n "" > $AXIOM_PATH/.sshconfig.new 
-echo -e "\tServerAliveInterval 60\n" >> $AXIOM_PATH/.sshconfig.new
-echo -e "\tServerAliveCountMax 60\n" >> $AXIOM_PATH/.sshconfig.new
+echo -n "" > $sshnew
+echo -e "\tServerAliveInterval 60\n" >> $sshnew
+echo -e "\tServerAliveCountMax 60\n" >> $sshnew
 sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $AXIOM_PATH/.sshconfig.new
+echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
 generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
 
 if [[ "$generate_sshconfig" == "private" ]]; then
@@ -278,9 +279,9 @@ if [[ "$generate_sshconfig" == "private" ]]; then
  for name in $(echo "$droplets" | jq -r '.[].name')
  do
  ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .networks.v4[] | select(.type==\"private\") | .ip_address")
- echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+ echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
  done
- mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+ mv $sshnew $AXIOM_PATH/.sshconfig
 
  elif [[ "$generate_sshconfig" == "cache" ]]; then 
  echo -e "Warning your SSH config generation toggle is set to 'Cache' for account : $(echo $current)."
@@ -292,9 +293,9 @@ if [[ "$generate_sshconfig" == "private" ]]; then
  for name in $(echo "$droplets" | jq -r '.[].name')
  do
  ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .networks.v4[] | select(.type==\"public\") | .ip_address")
- echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+ echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
  done
- mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+ mv $sshnew $AXIOM_PATH/.sshconfig
 fi
 
 

--- a/providers/ibm-functions.sh
+++ b/providers/ibm-functions.sh
@@ -285,11 +285,12 @@ generate_sshconfig() {
 	accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
 	current=$(ls -lh ~/.axiom/axiom.json | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
 	droplets="$(instances)"
-	echo -n "" > $AXIOM_PATH/.sshconfig.new 
-	echo -e "\tServerAliveInterval 60\n" >> $AXIOM_PATH/.sshconfig.new
-	echo -e "\tServerAliveCountMax 60\n" >> $AXIOM_PATH/.sshconfig.new
+        sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
+	echo -n "" > $sshnew 
+	echo -e "\tServerAliveInterval 60\n" >> $sshnew 
+	echo -e "\tServerAliveCountMax 60\n" >> $sshnew 
 	sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-	echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $AXIOM_PATH/.sshconfig.new
+	echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew 
 	generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
 
   if [[ "$generate_sshconfig" == "private" ]]; then
@@ -298,9 +299,9 @@ generate_sshconfig() {
   for name in $(echo "$droplets" | jq -r '.[].hostname')
   do 
   ip=$(echo "$droplets" | jq -r ".[] | select(.hostname==\"$name\") | .primaryBackendIpAddress")
-  echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+  echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew 
   done
-  mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+  mv $sshnew  $AXIOM_PATH/.sshconfig
 
 	elif [[ "$generate_sshconfig" == "cache" ]]; then
 	echo -e "Warning your SSH config generation toggle is set to 'Cache' for account : $(echo $current)."
@@ -312,9 +313,9 @@ generate_sshconfig() {
   for name in $(echo "$droplets" | jq -r '.[].hostname')
 	do 
 	ip=$(echo "$droplets" | jq -r ".[] | select(.hostname==\"$name\") | .primaryIpAddress")
-	echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+	echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew 
 	done
-	mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+	mv $sshnew  $AXIOM_PATH/.sshconfig
 fi
 }
 

--- a/providers/linode-functions.sh
+++ b/providers/linode-functions.sh
@@ -278,11 +278,12 @@ generate_sshconfig() {
 	accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
 	current=$(ls -lh ~/.axiom/axiom.json | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
 	droplets="$(instances)"
-	echo -n "" > $AXIOM_PATH/.sshconfig.new 
-	echo -e "\tServerAliveInterval 60\n" >> $AXIOM_PATH/.sshconfig.new
-	echo -e "\tServerAliveCountMax 60\n" >> $AXIOM_PATH/.sshconfig.new
+        sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
+	echo -n "" > $sshnew 
+	echo -e "\tServerAliveInterval 60\n" >> $sshnew 
+	echo -e "\tServerAliveCountMax 60\n" >> $sshnew 
 	sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-	echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $AXIOM_PATH/.sshconfig.new
+	echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew 
 	generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
 
  if [[ "$generate_sshconfig" == "private" ]]; then
@@ -292,11 +293,11 @@ generate_sshconfig() {
  for name in $(echo "$droplets" | jq -r '.[].label')
  do
  ip=$(echo "$droplets" | jq -r ".[] | select(.label==\"$name\") | .ipv4[1]")
- echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+ echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew 
  done
 
 
-  mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+  mv $sshnew  $AXIOM_PATH/.sshconfig
 
 	elif [[ "$generate_sshconfig" == "cache" ]]; then
 	echo -e "Warning your SSH config generation toggle is set to 'Cache' for account : $(echo $current)."
@@ -308,9 +309,9 @@ generate_sshconfig() {
         for name in $(echo "$droplets" | jq -r '.[].label')
         do
                 ip=$(echo "$droplets" | jq -r ".[] | select(.label==\"$name\") | .ipv4[0]")
-                echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $AXIOM_PATH/.sshconfig.new
+                echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew 
         done
-	mv $AXIOM_PATH/.sshconfig.new $AXIOM_PATH/.sshconfig
+	mv $sshnew  $AXIOM_PATH/.sshconfig
 fi
 }
 


### PR DESCRIPTION
Previously, running something like the following would cause errors ( specifically the error was a prompt to enter a password to authenticate to ssh). 

Why this happened: When the second scan ( assetfinder  for example) was called, the first command is still generating the SSH config, and since the sshconfig tmp location was `$AXIOM_PATH/.sshconfig.new`, axiom would overwrite and mangle the file. Now `$AXIOM_PATH/.sshconfig.new` is `$AXIOM_PATH/.sshconfig.new$RANDOM`, which prevents these types of issues.
```
axiom-scan subs -m subfinder &
axiom-scan subs -m assetfinder &
axiom-scan subs -m amass &

```

The previous workaround to this was running all subsequent axiom-scans with `--cache` ( shown below), this is no longer needed.

```
axiom-scan subs -m subfinder &
axiom-scan subs -m assetfinder --cache &
axiom-scan subs -m amass --cache & 
```

Additionally, the `generate_sshconfig` function is called earlier in axiom-scan, making for a more reliable generation.