### PR TITLE
Add cero module

### DIFF
--- a/images/provisioners/default.json
+++ b/images/provisioners/default.json
@@ -123,6 +123,9 @@
         "echo 'Installing chaos-client'",
         "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/projectdiscovery/chaos-client/cmd/chaos@latest'",
 
+        "echo 'Installing cero'",
+        "/bin/su -l op -c '/usr/local/go/bin/go install github.com/glebarez/cero@latest'",
+
         "echo 'Installing commix'",
         "git clone https://github.com/commixproject/commix.git /home/op/recon/commix",
 

--- a/modules/cero.json
+++ b/modules/cero.json
@@ -1,0 +1,5 @@
+
+[{
+    "command":"cat input | /home/op/go/bin/cero | tee output",
+    "ext":"txt"
+}]


### PR DESCRIPTION
[cero](https://github.com/glebarez/cero) is a `go` command that grabs the domains from a SSL certificate. It's useful to expand the possible known domain names of a partiular target. 

Test it in `zsh` shells with:
```zsh
axiom-scan =(echo google.com) -m cero -o out.txt
```
or replace `=(echo google.com)` with a file with your desired input.

Command Output example (truncated):
```
*.google.pt
*.googleadapis.com
*.googleapis.cn
*.googlevideo.com
*.gstatic.cn
*.gstatic-cn.com
googlecnapps.cn
```