### PR TITLE
Add preflight check and optional max scan runtime 

### DIFF
--- a/interact/axiom-exec
+++ b/interact/axiom-exec
@@ -70,6 +70,8 @@ use_tmux=false
 instance=false
 keep_logs=false
 quick_execution=false
+pre_flight=true
+preflight_timeout=5
 
 ###########################################################################################################
 # Help Menu:
@@ -99,16 +101,20 @@ function usage() {
         echo -e "    Execute commands in a detacted tmux session (commands run in the background). The default tmux session name is axiom-exec+\$TIMESTAMP, or supply a custom tmux session name"
         echo -e "  --sshconfig <sshconfig_file> (optional string)"
         echo -e "    Path to axiom's SSH config (default is ~/.axiom/.sshconfig)"
-        echo -e "  -q/--quiet"
+        echo -e "  -q/--quiet (optional)"
         echo -e "    Disable progress bar, and reduce verbosity"
-        echo -e "  --debug"
+        echo -e "  --debug (optional)"
         echo -e "    Enable debug mode (VERY VERBOSE!)"
-        echo -e "  --cache"
+        echo -e "  --cache (optional)"
         echo -e "    Temporarily do not generate SSH config and instead connect with cached SSH config"
-        echo -e "  --logs"
+        echo -e "  --logs (optional)"
         echo -e "    Do not delete logs (logs will be stored in ~/.axiom/logs/exec/axiom-exec\$TIMESTAMP)"
-        echo -e "  --quick"
+        echo -e "  --quick (optional)"
         echo -e "    A faster but less reliable execution"
+        echo -e "  --skip-preflight (optional)"
+        echo -e "    Do not automatically remove instances that cant be reached (default removes instances from the queue that cant be reached)"
+        echo -e "  --preflight-timeout <int>"
+        echo -e "    Specifies the timeout (in seconds) used when connecting to the SSH server, instead of using the default 5 seconds"
         echo -e "  --help"
         echo -e "    Display this help menu"
 }
@@ -181,6 +187,18 @@ do
             quick_execution=true
             set=true
             pass+=($i)
+        fi
+        if [[ "$arg" == "--skip-preflight" ]]; then
+            pre_flight=false
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--preflight-timeout" ]] ; then
+            n=$((i+1))
+            preflight_timeout=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
         fi
         if  [[ "$set" != "true" ]]; then
             args="$args $arg"
@@ -330,6 +348,16 @@ ssh_exit_command="ssh -F $sshconfig -O exit -o StrictHostKeyChecking=no"
 #
 stty -echoctl
 trap clean_up SIGINT SIGTERM
+
+###########################################################################################################
+# preflight check
+#
+if [[ $pre_flight == true ]]; then
+ssh_command_preflight="ssh -F $sshconfig -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=$preflight_timeout"
+$interlace_cmd_silent -c "$ssh_command_preflight _target_ 'echo _target_' >> $tmp/hosts_preflight"
+cat "$tmp/hosts_preflight" | sort -u  > "$tmp/hosts"
+cp "$tmp/hosts_preflight" "$tmp/selected.conf"
+fi
 
 ###########################################################################################################
 #  store bash command in a file and upload it to remote instances with axiom-scp

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -105,7 +105,7 @@ CONFIGURATIONS:
 OPTIMIZATIONS:
    --skip-preflight            do not automatically remove instances that cant be reached (default removes instances from the queue that cant be reached)
    --preflight-timeout int[]   specifies the timeout (in seconds) used when connecting to the SSH server, instead of using the default 5 seconds
-   --max-runtime DURATION[]    kill scan it if still running after DURATION. DURATION is a floating point number with an optional suffix: 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
+   --max-runtime DURATION[]    kill scan if still running after DURATION. DURATION is a floating point number with an optional suffix: 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
 
 OUTPUT:
    -o string[]          output as default (the first ext mentioned in the module) 

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -139,10 +139,10 @@ EOF
 #
 clean_up() { 
     kill -0 $remotetailPID 2>  /dev/null && kill -9 $remotetailPID  &> /dev/null
-    kill -0 $tailPID 2>  /dev/null && kill -9 $tailPID  &> /dev/null
     kill -0 $downloaderPID 2>  /dev/null && kill -9 $downloaderPID  &> /dev/null
     echo -e "${Green}CTRL+C Interrupt, cleaning up and downloading output..${Color_Off}."
-    $interlace_cmd_nobar -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
+    $interlace_cmd_nobar -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'  >> $tmp/logs/_target_ 2>&1 "
+    kill -0 $tailPID 2>  /dev/null && kill -9 $tailPID  &> /dev/null
     if [[ "$command" =~ "_target_" ]]; then
      $interlace_cmd_nobar -c "axiom-scp _target_:$scan_dir/output/ $tmp/output/ --cache -F=$sshconfig >/dev/null 2>&1"
     else
@@ -776,7 +776,6 @@ ssh_exit_command="ssh -F $sshconfig -O exit -o StrictHostKeyChecking=no"
 
 interlace_cmd="$(which interlace) --silent -tL $tmp/hosts -threads $total_instances"
 interlace_cmd_nobar="$(which interlace) --no-bar --silent -tL $tmp/hosts -threads $total_instances"
-interlace_cmd_silent="$(which interlace) --no-bar -tL $tmp/hosts -threads $total_instances"
 
 ###########################################################################################################
 # preflight check
@@ -1052,7 +1051,7 @@ if [[ "$command" =~ "_target_" ]]; then
  echo $remotetailPID > $tmp/status/remotetailPID
  $interlace_cmd_nobar -c "$ssh_command _target_ 'tmux new -d -s $uid && tmux send-keys -t $uid \"cd $scan_dir; interlace -threads $threads -tL input -cL command -o output > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2) ; touch _target_\" ENTER ' \"&& tmux send-keys -t $uid exit ENTER\""
  wait $remotetailPID  >> /dev/null 2>&1
- $interlace_cmd_silent -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
+ $interlace_cmd_nobar -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results' >> $tmp/logs/_target_ 2>&1"
  $interlace_cmd_nobar -c "axiom-scp _target_:$scan_dir/output/ $tmp/output/ --cache -F=$sshconfig >/dev/null 2>&1"
 
 ###########################################################################################################
@@ -1067,9 +1066,9 @@ else
  timeout $max_scan_runtime $interlace_cmd_nobar -c "$ssh_command _target_ 'cd $scan_dir && touch stderr.log stdout.log && tail -f stderr.log & tail -f stdout.log' >> $tmp/logs/_target_ 2>&1 " &
  remotetailPID=$!
  echo $remotetailPID > $tmp/status/remotetailPID
-  $interlace_cmd_nobar -c "$ssh_command _target_ 'tmux new -d -s $uid && tmux send-keys -t $uid \"cd $scan_dir; bash -i command  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2) ; touch _target_\" ENTER ' \"&& tmux send-keys -t $uid exit ENTER\""
+ $interlace_cmd_nobar -c "$ssh_command _target_ 'tmux new -d -s $uid && tmux send-keys -t $uid \"cd $scan_dir; bash -i command  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2) ; touch _target_\" ENTER ' \"&& tmux send-keys -t $uid exit ENTER\""
  wait $remotetailPID  >> /dev/null 2>&1
- $interlace_cmd_silent -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
+ $interlace_cmd_nobar -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results' >> $tmp/logs/_target_ 2>&1"
  $interlace_cmd_nobar -c "axiom-scp _target_:$scan_dir/output $tmp/output/_target_.$ext --cache -F=$sshconfig >/dev/null 2>&1"
 fi
 

--- a/interact/axiom-scan
+++ b/interact/axiom-scan
@@ -102,6 +102,11 @@ CONFIGURATIONS:
    --config string[]           replace _config_ in module with user-provided configuration file (must be a configuration file on the remote instances)
    --local-config string[]     replace _config_ in module with user-provided local configuration file to upload ( must be a local configuration file)
 
+OPTIMIZATIONS:
+   --skip-preflight            do not automatically remove instances that cant be reached (default removes instances from the queue that cant be reached)
+   --preflight-timeout int[]   specifies the timeout (in seconds) used when connecting to the SSH server, instead of using the default 5 seconds
+   --max-runtime DURATION[]    kill scan it if still running after DURATION. DURATION is a floating point number with an optional suffix: 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
+
 OUTPUT:
    -o string[]          output as default (the first ext mentioned in the module) 
    -oD/-oA string[]     output as directory (must also be supplied in the module using "ext":"dir" or "ext":"")
@@ -223,11 +228,11 @@ add_extra_args() {
             new_command="$new_command $piece $args"
             args_set=""true
         else
-            new_command="$new_command $piece"
+            new_command="$new_command$piece"
         fi
 
         if [[ "$counter" -lt "$pieces" ]]; then
-            new_command="$new_command | "
+            new_command="$new_command|"
             counter=$((counter+1))
         fi
     done
@@ -378,6 +383,9 @@ quiet="false"
 nuclei_templates="false"
 user_specified_config="false"
 local_config="false"
+pre_flight=true
+preflight_timeout=5
+max_scan_runtime=0
 
 ###########################################################################################################
 #  Parse command line arguments 
@@ -390,6 +398,11 @@ do
         set=false
         if [[ "$i" == 1 ]]; then
             input="$1"
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--debug" ]]; then
+            set -xv
             set=true
             pass+=($i)
         fi
@@ -448,6 +461,18 @@ do
             anew="true"
             outfile=$(echo ${!n})
             echo "sending output file to anew when completed"
+            set=true
+            pass+=($i)
+            pass+=($n)
+        fi
+        if [[ "$arg" == "--skip-preflight" ]]; then
+            pre_flight=false
+            set=true
+            pass+=($i)
+        fi
+        if [[ "$arg" == "--preflight-timeout" ]] ; then
+            n=$((i+1))
+            preflight_timeout=$(echo ${!n})
             set=true
             pass+=($i)
             pass+=($n)
@@ -551,11 +576,6 @@ do
             set=true
             pass+=($i)
         fi
-        if [[ "$arg" == "--debug" ]]; then
-            debug="true"
-            set=true
-            pass+=($i)
-        fi
         if [[ "$arg" == "--rm-logs" ]]; then
             keeplogs="false"
             set=true
@@ -570,6 +590,13 @@ do
             split="false"
             set=true
             pass+=($i)
+        fi
+        if [[ "$arg" == "--max-runtime" ]]; then
+            n=$((i+1))
+            max_scan_runtime=$(echo ${!n})
+            set=true
+            pass+=($i)
+            pass+=($n)
         fi
         if  [[ "$set" != "true" ]]; then
             args="$args $arg"
@@ -749,6 +776,21 @@ ssh_exit_command="ssh -F $sshconfig -O exit -o StrictHostKeyChecking=no"
 
 interlace_cmd="$(which interlace) --silent -tL $tmp/hosts -threads $total_instances"
 interlace_cmd_nobar="$(which interlace) --no-bar --silent -tL $tmp/hosts -threads $total_instances"
+interlace_cmd_silent="$(which interlace) --no-bar -tL $tmp/hosts -threads $total_instances"
+
+###########################################################################################################
+# preflight check
+#
+if [[ $pre_flight == true ]]; then
+ssh_command_preflight="ssh -F $sshconfig -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=$preflight_timeout"
+$interlace_cmd -c "$ssh_command_preflight _target_ 'echo _target_' >> $tmp/hosts_preflight"
+cat "$tmp/hosts_preflight" | sort -u  > "$tmp/hosts"
+cp "$tmp/hosts_preflight" "$tmp/selected.conf"
+total_instances="$(wc -l "$tmp/hosts" | awk '{ print $1 }')"
+lines="$(wc -l "$input_file" | awk '{ print $1 }')"
+total=$(wc -l "$tmp/selected.conf" | awk '{ print $1 }')
+instances=$(cat "$tmp/hosts")
+fi
 
 ###########################################################################################################
 #  Parse the default extention from the module
@@ -1005,12 +1047,12 @@ if [[ "$command" =~ "_target_" ]]; then
  sleep 3
  downloader &
  downloaderPID=$!
- $interlace_cmd_nobar -c "$ssh_command _target_ 'cd $scan_dir && touch stderr.log stdout.log && tail -f stderr.log & tail -f stdout.log' >> $tmp/logs/_target_ 2>&1 " &
+ timeout $max_scan_runtime $interlace_cmd_nobar -c "$ssh_command _target_ 'cd $scan_dir && touch stderr.log stdout.log && tail -f stderr.log & tail -f stdout.log' >> $tmp/logs/_target_ 2>&1 " &
  remotetailPID=$!
  echo $remotetailPID > $tmp/status/remotetailPID
  $interlace_cmd_nobar -c "$ssh_command _target_ 'tmux new -d -s $uid && tmux send-keys -t $uid \"cd $scan_dir; interlace -threads $threads -tL input -cL command -o output > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2) ; touch _target_\" ENTER ' \"&& tmux send-keys -t $uid exit ENTER\""
  wait $remotetailPID  >> /dev/null 2>&1
- $interlace_cmd_nobar -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
+ $interlace_cmd_silent -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
  $interlace_cmd_nobar -c "axiom-scp _target_:$scan_dir/output/ $tmp/output/ --cache -F=$sshconfig >/dev/null 2>&1"
 
 ###########################################################################################################
@@ -1022,12 +1064,12 @@ else
  sleep 3
  downloader &
  downloaderPID=$!
- $interlace_cmd_nobar -c "$ssh_command _target_ 'cd $scan_dir && touch stderr.log stdout.log && tail -f stderr.log & tail -f stdout.log' >> $tmp/logs/_target_ 2>&1 " &
+ timeout $max_scan_runtime $interlace_cmd_nobar -c "$ssh_command _target_ 'cd $scan_dir && touch stderr.log stdout.log && tail -f stderr.log & tail -f stdout.log' >> $tmp/logs/_target_ 2>&1 " &
  remotetailPID=$!
  echo $remotetailPID > $tmp/status/remotetailPID
- $interlace_cmd_nobar -c "$ssh_command _target_ 'tmux new -d -s $uid && tmux send-keys -t $uid \"cd $scan_dir; bash -i command  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2) ; touch _target_\" ENTER ' \"&& tmux send-keys -t $uid exit ENTER\""
+  $interlace_cmd_nobar -c "$ssh_command _target_ 'tmux new -d -s $uid && tmux send-keys -t $uid \"cd $scan_dir; bash -i command  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2) ; touch _target_\" ENTER ' \"&& tmux send-keys -t $uid exit ENTER\""
  wait $remotetailPID  >> /dev/null 2>&1
- $interlace_cmd_nobar -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
+ $interlace_cmd_silent -c "$ssh_command _target_ '[ -f $scan_dir/_target_ ] && echo _target_ scan finished || echo _target_ scan was still running but downloading partial results'"
  $interlace_cmd_nobar -c "axiom-scp _target_:$scan_dir/output $tmp/output/_target_.$ext --cache -F=$sshconfig >/dev/null 2>&1"
 fi
 


### PR DESCRIPTION
* Preflight check automatically removes instances from the queue if they can’t be reached 
* `—max-runtime` allows specifying the timeout for axiom-scan 