### PR TITLE
Trim IPs returned to make sure only 1 is output

### DIFF
--- a/providers/do-functions.sh
+++ b/providers/do-functions.sh
@@ -32,7 +32,7 @@ instance_id() {
 # takes one argument, name of instance, returns raw IP address
 instance_ip() {
 	name="$1"
-	instances | jq -r ".[]? | select(.name==\"$name\") | .networks.v4[]? | select(.type==\"public\") | .ip_address"
+	instances | jq -r ".[]? | select(.name==\"$name\") | .networks.v4[]? | select(.type==\"public\") | .ip_address" | head -1
 }
 
 instance_ip_cache() {


### PR DESCRIPTION
If other public IPs are configured (i.e. reserved IP) multiple IPs are output and breaks the SSH config generation which prevents scanning

I just opened issue #613 for this, but I think the solution is very simple. With DO reserved IPs, the droplet can be accessed via any that is returned and set to public (barring any host-specific configurations). For axiom's purposes, it doesn't matter which IP is used, so just get the first one that is returned and call it a day.

Quick verified it locally:
```
# doctl compute droplet list -o json | jq -r ".[]? | select(.name==\"recon-automation-manager-vm\") | .networks.v4[]? | select(.type==\"public\") | .ip_address"
137.184.x.y
167.172.x.y
167.172.x.y
# doctl compute droplet list -o json | jq -r ".[]? | select(.name==\"recon-automation-manager-vm\") | .networks.v4[]? | select(.type==\"public\") | .ip_address" | head -1
137.184.x.y
#
```