### PR TITLE
Updated aws.json to create encrypted snapshots

### DIFF
--- a/images/builders/aws.json
+++ b/images/builders/aws.json
@@ -11,6 +11,7 @@
       		"device_name": "/dev/sda1",
       		"volume_type": "gp2",
       		"volume_size": 20,
+          "encrypted": true,
       		"delete_on_termination": true
  		}
 	],


### PR DESCRIPTION
With this feature enabled all newly built AWS axiom ami machine images, snapshots and volumes will now be encrypted by default. 