### PR TITLE
chore: remove deprecated cf-check module

### DIFF
--- a/modules/cf-check.json
+++ b/modules/cf-check.json
@@ -1,4 +1,0 @@
-[{
-        "command":"cat input | docker run --rm -i --mount type=bind,source=\"$(pwd)\",target=/data axiom/cf-check | tee output",
-        "ext":"txt"
-}]


### PR DESCRIPTION
This just removes `cf-check` from modules- https://github.com/Cgboal/exclude-cdn is an excellent alternative.
