### PR TITLE
Update nuclei.json

### DIFF
--- a/modules/nuclei.json
+++ b/modules/nuclei.json
@@ -1,5 +1,5 @@
 [{
-  "command":"/home/op/go/bin/nuclei -silent -update-templates ; cat input | /home/op/go/bin/nuclei -t _wordlist_ -o output",
+  "command":"cat input | /home/op/go/bin/nuclei -t _wordlist_ -o output",
   "ext":"txt",
   "wordlist":"/home/op/nuclei-templates"
 }]

--- a/modules/nuclei.json
+++ b/modules/nuclei.json
@@ -1,5 +1,5 @@
 [{
-  "command":"cat input | /home/op/go/bin/nuclei -t _wordlist_ -o output",
+  "command":"/home/op/go/bin/nuclei -update -silent ; cat input | /home/op/go/bin/nuclei -t _wordlist_ -o output",
   "ext":"txt",
   "wordlist":"/home/op/nuclei-templates"
 }]


### PR DESCRIPTION
``/home/op/go/bin/nuclei -silent -update-templates`` is  no longer required since nuclei autoupdates the templates while starting the scan.