### PR TITLE
Fix AWS function key bug

### DIFF
--- a/providers/aws-functions.sh
+++ b/providers/aws-functions.sh
@@ -318,7 +318,7 @@ create_instance() {
   #  --no-header 2>/dev/null) ||
   #keyid=$(doctl compute ssh-key list | grep "$sshkey_fingerprint" | awk '{ print $1 }')
   
-  aws ec2 run-instances --image-id "$image_id" --count 1 --instance-type --region "$region" "$size" --key-name axiom --security-groups axiom --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$name}]" 2>&1 >> /dev/null
+  aws ec2 run-instances --image-id "$image_id" --count 1 --instance-type --region "$region" "$size" --security-groups axiom --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$name}]" 2>&1 >> /dev/null
   
   sleep 260
 }


### PR DESCRIPTION
when AWS ec2 instances are created, the command includes the `--key-name axiom` in the command. Since there is no `axiom` key created on start up, this will error out. SSH key uploads are handled during the image build phase, so this is not necessary anymore. Simple fix