### PR TITLE
PR: axiom-account fails on first run when cloud provider is Digital Ocean

### DIFF
--- a/interact/axiom-account
+++ b/interact/axiom-account
@@ -61,8 +61,7 @@ then
                 fi 
                 if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
                     sudo pacman -Syu doctl --noconfirm
-                fi
-                if [[ $OS == "Linux" ]] ; then
+                else
                     wget -q -O /tmp/doctl.tar.gz https://github.com/digitalocean/doctl/releases/download/v1.66.0/doctl-1.66.0-linux-amd64.tar.gz && tar -xvzf /tmp/doctl.tar.gz && sudo mv doctl /usr/bin/doctl && rm /tmp/doctl.tar.gz
                 fi
                 token="$(jq -r '.do_key' "$AXIOM_PATH"/accounts/"$1".json)"


### PR DESCRIPTION
Issue: https://github.com/pry0cc/axiom/issues/672