### PR TITLE
aws fixes

### DIFF
--- a/providers/aws-functions.sh
+++ b/providers/aws-functions.sh
@@ -5,18 +5,21 @@ source "$AXIOM_PATH/interact/includes/appliance.sh"
 LOG="$AXIOM_PATH/log.txt"
 
 poweron() {
-instance_name="$1"
-doctl compute droplet-action power-on $(instance_id $instance_name)
+  instance_name="$1"
+  id=$(instance_id "$instance_name")
+  aws ec2 start-instances --instance-ids "$id"
 }
 
 poweroff() {
-instance_name="$1"
-doctl compute droplet-action power-off $(instance_id $instance_name)
+  instance_name="$1"
+  id=$(instance_id "$instance_name")
+  aws ec2 stop-instances --instance-ids "$id"
 }
 
-reboot(){
-instance_name="$1"
-doctl compute droplet-action reboot $(instance_id $instance_name)
+reboot() {
+  instance_name="$1"
+  id=$(instance_id "$instance_name")
+  aws ec2 reboot-instances --instance-ids "$id"
 }
 
 # takes no arguments, outputs JSON object with instances


### PR DESCRIPTION
- Makes the installation of `aws` cli selective- it's quite annoying being prompted to overwrite each of the aws files (this is the current behavior, if one runs `axiom-configure` on a machine that has `aws` installed already.)
- Currently if we run `axiom-build` a 2nd time for aws it will fail, because the security group already exists. To work around this, I am now doing a blind delete prior to creating a fresh SG.
- Implements some misc functions in the aws helper
