### PR TITLE
Transfer DO image

### DIFF
--- a/interact/axiom-fleet
+++ b/interact/axiom-fleet
@@ -49,6 +49,32 @@ init_timeout=4
 init_sleep=4
 
 ###########################################################################################################
+# DO Region Transfer
+# Transfer image to region if requested in that region yet does not exist. DO only
+#
+region_transfer(){
+if [[ "$provider" == "do" ]]; then
+ avail_image_id_regions=$(doctl compute image get "$image_id" -o json| jq -r '.[] | .regions[]')
+ requested_image_id_regions="$regionargs"
+ if [[ "$avail_image_id_regions" != *"$requested_image_id_regions"* ]]; then
+  echo -e "${Color_Off}]"
+  echo -e "${BYellow}instance ${Blue}"$name"${BYellow} requested image in region ${BRed}$regionargs${BYellow}, however image ${BRed}$image_name${BYellow} only exists in ${BRed}$(echo $avail_image_id_regions | tr '\n' ',')"
+  echo -e "${BYellow}axiom will attempt to transfer image to new region, this can take a few minutes please be patient...${Color_Off}"
+  doctl compute image-action transfer $image_id --region $regionargs --wait
+   if [ $? -eq 0 ]; then
+    echo -e "\033[32mimage transfer succeeded\033[0m"
+    echo -e "${BWhite}waiting 90 seconds before continuing...${Color_Off}"
+    sleep 90
+   else
+    echo -e "${BRed}image transfer failed... you might need to pick a different region. '${BWhite}axiom-region ls${BRed}' to list regions. '${BWhite}axiom-images ls${BRed}' to list images${Color_Off}"
+   fi
+ echo -n -e "${BWhite}Instances: ${Color_Off}[ ${Blue}"
+ fi
+echo -n -e ${Blue}
+fi 
+}
+
+###########################################################################################################
 # Help Menu
 # 
 function usage() {
@@ -279,6 +305,14 @@ regionargs="${regions_to_cycle[o]}"
 #
 if [ -z ${regionargs:+x} ]; then
 regionargs="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
+fi
+
+###########################################################################################################
+# DO Region Transfer
+# Transfer image to region if requested in that region yet does not exist. DO only
+#
+if [[ "$provider" == "do" ]]; then
+  region_transfer
 fi
 
 # create instance

--- a/providers/do-functions.sh
+++ b/providers/do-functions.sh
@@ -331,7 +331,7 @@ create_instance() {
     --no-header 2>/dev/null) ||
   keyid=$(doctl compute ssh-key list | grep "$sshkey_fingerprint" | awk '{ print $1 }')
 
-  doctl compute droplet create "$name" --image "$image_id" --size "$size" --region "$region" --enable-ipv6 --user-data-file "$boot_script" --ssh-keys "$keyid" >/dev/null 2>&1
+  doctl compute droplet create "$name" --image "$image_id" --size "$size" --region "$region" --enable-ipv6 --user-data-file "$boot_script" --ssh-keys "$keyid" >/dev/null
   sleep 260
 }
 


### PR DESCRIPTION
DO stands out from other providers in that it does not automatically transfer an image to a new region simply because it was requested in that region. 
Now if an image is requested in a region where it does not yet exist, axiom will make an attempt to transfer it. 

```
axiom-fleet -i 15 -r ams3,blr1,fra1,lon1,nyc1,nyc3,sfo3,sgp1,syd1,tor1
```

<img width="769" alt="Screen Shot 2023-03-28 at 9 48 51 PM" src="https://user-images.githubusercontent.com/21030907/228413829-24136b50-1eb4-47ad-ba8c-3d6ee22495f2.png">
