### PR TITLE
Update ffuf_base.json

### DIFF
--- a/modules/ffuf_base.json
+++ b/modules/ffuf_base.json
@@ -1,6 +1,6 @@
 [{
 	"command":"/home/op/go/bin/ffuf -w _wordlist_ -u '_target_/FUZZ' -o _output_/_cleantarget_ ",
     "wordlist":"/home/op/lists/seclists/Discovery/Web-Content/big.txt",
-	"ext":"csv",
+	"ext":"txt",
 	"threads":"1"
 }]


### PR DESCRIPTION
Ffuf v2 does not fully support csv on all options, I think is better to leave the output as default txt, so the user will be able to generate plain text or json output (or any other for later post-processing), but not limit the output to csv which fully sucks to parse or piping to other processes