### PR TITLE
fix puredns bruteforce modules

### DIFF
--- a/modules/puredns-bruteforce.json
+++ b/modules/puredns-bruteforce.json
@@ -1,5 +1,5 @@
 [{
-    "command":"echo _target_ | /home/op/go/bin/puredns bruteforce _wordlist_ _target_ -r /home/op/lists/resolvers.txt  | tee _output_/_target_",
+    "command":"/home/op/go/bin/puredns bruteforce _wordlist_ _target_ -r /home/op/lists/resolvers.txt  | tee _output_/_target_",
     "ext":"txt",
     "wordlist":"/home/op/lists/seclists/Discovery/DNS/dns-Jhaddix.txt",
     "threads":"1"


### PR DESCRIPTION
puredns bruteforce cannot accept both STDIN and ARGS