### PR TITLE
Update azure-functions.sh

### DIFF
--- a/providers/azure-functions.sh
+++ b/providers/azure-functions.sh
@@ -75,7 +75,7 @@ create_instance() {
 	#location="$(az account list-locations | jq -r ".[] | select(.name==\"$region\") | .displayName")"
 	location="$region"
 
-    az vm create --resource-group $resource_group --name "$name" --image "$image_id" --location "$location" --size "$size_slug" --tags "$name"=True --admin-username op --ssh-key-values ~/.ssh/$sshkey.pub  >/dev/null 2>&1 
+  az vm create --resource-group $resource_group --name "$name" --image "$image_id" --location "$location" --size "$size_slug" --tags "$name"=True --os-disk-delete-option delete --data-disk-delete-option delete --nic-delete-option delete --admin-username op --ssh-key-values ~/.ssh/$sshkey.pub >/dev/null 2>&1
 	az vm open-port --resource-group $resource_group --name "$name" --port 0-65535 >/dev/null 2>&1 
 	sleep 260
 }


### PR DESCRIPTION
This new flags allow deleting on cascade all linked resources to the VM itself, like the NIC or the virtual disk, at the time of deleting the vm. 

The additional commands to remove these orphaned resources (NIC, disk, NRG) from previous commits will remain as a safety check :)