### PR TITLE
Raspberry PI Integration and Checks

### DIFF
--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -229,7 +229,7 @@ if [[ $BASEOS == "Linux" ]]; then
         echo -e "${Blue}Installing other repo deps...${Color_Off}"
         DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install git ruby python3-pip curl iputils-ping net-tools unzip xsltproc bc rsync sudo wget nano bsdmainutils openssh-server fail2ban -y 
         echo -e "${Blue}Installing jq...${Color_Off}"
-        sudo wget -q -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x /usr/bin/jq
+        sudo wget -q -O /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"
         wget -q -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.8.1/packer_1.8.1_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip 
         echo -e "${Blue}Installing Interlace...${Color_Off}"

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -231,7 +231,7 @@ if [[ $BASEOS == "Linux" ]]; then
         echo -e "${Blue}Installing jq...${Color_Off}"
         sudo wget -q -O /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64 && sudo chmod +x /usr/bin/jq
         echo -e "${Blue}Installing packer...${Color_Off}"
-        wget -q -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.8.1/packer_1.8.1_linux_amd64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip 
+        wget -q -O /tmp/packer.zip https://releases.hashicorp.com/packer/1.8.1/packer_1.8.1_linux_arm64.zip && cd /tmp/ && unzip packer.zip && sudo mv packer /usr/bin/ && rm /tmp/packer.zip 
         echo -e "${Blue}Installing Interlace...${Color_Off}"
         sudo rm -fr /tmp/interlace
         git clone https://github.com/codingo/Interlace.git /tmp/interlace


### PR DESCRIPTION
Made this fork and now it can be used directly to install and run Axiom in Raspberry Pi(4). Considering it works as a local system and with lots of API keys and secrets, keep it on a LAN is much better option that leaving it on the cloud. Tried and tested and works awesome. 

FYI this pull request is just for giving out the info that axiom can be configured to work on Raspberry Pi, please don't merge it. 