### PR TITLE
dnsx installation fix

### DIFF
--- a/images/provisioners/classic.json
+++ b/images/provisioners/classic.json
@@ -179,7 +179,7 @@
         "echo 'Installing waybackurls'",
         "/bin/su -l op -c 'go install github.com/tomnomnom/hacks/waybackurls@latest'",
         "echo 'Installing dnsx'",
-        "/bin/su -l op -c 'go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
+        "/bin/su -l op -c 'go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
         "echo 'Installing shuffledns'",
         "/bin/su -l op -c 'go install github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest'",
         "echo 'Installing chaos client'",

--- a/images/provisioners/default.json
+++ b/images/provisioners/default.json
@@ -155,7 +155,7 @@
         "git clone https://github.com/vortexau/dnsvalidator.git /home/op/recon/dnsvalidator && cd /home/op/recon/dnsvalidator/ && sudo python3 setup.py install",
 
         "echo 'Installing dnsx'",
-        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
+        "/bin/su -l op -c 'GO111MODULE=on /home/op/go/bin/go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
 
         "echo 'Installing ERLPopper'",
         "git clone https://github.com/maikthulhu/ERLPopper.git /home/op/recon/ERLPopper",

--- a/images/provisioners/default.json
+++ b/images/provisioners/default.json
@@ -155,7 +155,7 @@
         "git clone https://github.com/vortexau/dnsvalidator.git /home/op/recon/dnsvalidator && cd /home/op/recon/dnsvalidator/ && sudo python3 setup.py install",
 
         "echo 'Installing dnsx'",
-        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
+        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
 
         "echo 'Installing ERLPopper'",
         "git clone https://github.com/maikthulhu/ERLPopper.git /home/op/recon/ERLPopper",

--- a/images/provisioners/reconftw.json
+++ b/images/provisioners/reconftw.json
@@ -122,7 +122,7 @@
         "git clone https://github.com/vortexau/dnsvalidator.git /home/op/recon/dnsvalidator && cd /home/op/recon/dnsvalidator/ && sudo python3 setup.py install",
 
         "echo 'Installing dnsx'",
-        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
+        "/bin/su -l op -c 'GO111MODULE=on /home/op/go/bin/go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
 
         "echo 'Installing ffuf'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/ffuf/ffuf/v2@latest'",

--- a/images/provisioners/reconftw.json
+++ b/images/provisioners/reconftw.json
@@ -122,7 +122,7 @@
         "git clone https://github.com/vortexau/dnsvalidator.git /home/op/recon/dnsvalidator && cd /home/op/recon/dnsvalidator/ && sudo python3 setup.py install",
 
         "echo 'Installing dnsx'",
-        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
+        "/bin/su -l op -c 'GO111MODULE=on /usr/local/go/bin/go1.22.0 install github.com/projectdiscovery/dnsx/cmd/dnsx@latest'",
 
         "echo 'Installing ffuf'",
         "/bin/su -l op -c '/usr/local/go/bin/go install github.com/ffuf/ffuf/v2@latest'",


### PR DESCRIPTION
The latest version of DNSX now only supports Go 1.21 and above.

Reference: https://github.com/projectdiscovery/dnsx?tab=readme-ov-file#installation-instructions