### PR TITLE
Update go version in default.json

### DIFF
--- a/images/provisioners/default.json
+++ b/images/provisioners/default.json
@@ -53,8 +53,8 @@
         "sudo service sshd restart",
         "chmod +x /etc/update-motd.d/00-header",
 
-        "echo 'Installing Golang 1.20.4'",
-        "wget -q https://golang.org/dl/go1.20.4.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.20.4.linux-amd64.tar.gz && rm go1.20.4.linux-amd64.tar.gz",
+        "echo 'Installing Golang 1.22.2'",
+        "wget -q https://golang.org/dl/go1.22.2.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz && rm go1.22.2.linux-amd64.tar.gz",
         "export GOPATH=/home/op/go",
 
         "echo 'Installing Golang 1.22.0'",


### PR DESCRIPTION
@0xtavian By default, axiom uses go version 1.20.4

```
nishant57@v2202403199255261138:~/BB$ axiom-exec --cache 'go version'
100%|███████████████████████████████████████████| 15/15 [00:00<00:00, 55.50it/s]
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
go version go1.20.4 linux/amd64
```

But a lot of tools use go version > 1.21. Like naabu:
```
nishant57@v2202403199255261138:~/BB$ axiom-exec --cache 'go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@latest'
# github.com/projectdiscovery/fastdialer/fastdialer/metafiles
go/pkg/mod/github.com/projectdiscovery/fastdialer@v0.0.61/fastdialer/metafiles/shared.go:49:21: undefined: sync.OnceFunc
go/pkg/mod/github.com/projectdiscovery/fastdialer@v0.0.61/fastdialer/metafiles/shared.go:73:19: undefined: sync.OnceFunc
note: module requires Go 1.21
# github.com/projectdiscovery/fastdialer/fastdialer/metafiles
go/pkg/mod/github.com/projectdiscovery/fastdialer@v0.0.61/fastdialer/metafiles/shared.go:49:21: undefined: sync.OnceFunc
go/pkg/mod/github.com/projectdiscovery/fastdialer@v0.0.61/fastdialer/metafiles/shared.go:73:19: undefined: sync.OnceFunc
note: module requires Go 1.21
```

Removing and installing new go version:
```
nishant57@v2202403199255261138:~/BB$ axiom-exec --cache 'sudo rm -rf /usr/local/go && wget -q https://golang.org/dl/go1.22.2.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz && rm go1.22.2.linux-amd64.tar.gz'
```

```
nishant57@v2202403199255261138:~/BB$ axiom-exec --cache 'go version'
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 15/15 [00:00<00:00, 59.22it/s]
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
go version go1.22.2 linux/amd64
```
Now installing naabu:
```
nishant57@v2202403199255261138:~/BB$ axiom-exec --cache 'go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@latest'
github.com/projectdiscovery/naabu/v2/pkg/scan
github.com/projectdiscovery/naabu/v2/pkg/runner
github.com/projectdiscovery/naabu/v2/pkg/scan
github.com/projectdiscovery/naabu/v2/pkg/runner
github.com/projectdiscovery/naabu/v2/cmd/naabu
github.com/projectdiscovery/naabu/v2/cmd/naabu
....
```
Not just naabu, alot of tools now requires latest go.

Also please check these lines, I don't think they are necessary:
```
        "echo 'Installing Golang 1.22.0'",
        "/bin/su -l op -c '/usr/local/go/bin/go install golang.org/dl/go1.22.0@latest'",
        "/bin/su -l op -c '/home/op/go/bin/go1.22.0 download'",
```